### PR TITLE
Add some cyrillic emoticon equivalents for conversion

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -40,6 +40,7 @@ public class ChatSanitizationManager : IChatSanitizationManager
         { ":>", "chatsan-grins" },
         { ":<", "chatsan-pouts" },
         { "xD", "chatsan-laughs" },
+        { "хд", "chatsan-laughs" },
         { ";-;", "chatsan-cries" },
         { ";_;", "chatsan-cries" },
         { ":u", "chatsan-smiles-smugly" },
@@ -51,17 +52,22 @@ public class ChatSanitizationManager : IChatSanitizationManager
         { ":b", "chatsan-stick-out-tongue" },
         { "0-0", "chatsan-wide-eyed" },
         { "o-o", "chatsan-wide-eyed" },
+        { "о-о", "chatsan-wide-eyed" }, // cyrillic о
         { "o.o", "chatsan-wide-eyed" },
+        { "о.о", "chatsan-wide-eyed" }, // cyrillic о
         { "._.", "chatsan-surprised" },
         { ".-.", "chatsan-confused" },
         { "-_-", "chatsan-unimpressed" },
         { "o/", "chatsan-waves" },
+        { "о/", "chatsan-waves" }, // cyrillic о
         { "^^/", "chatsan-waves" },
         { ":/", "chatsan-uncertain" },
         { ":\\", "chatsan-uncertain" },
         { "lmao", "chatsan-laughs" },
         { "lol", "chatsan-laughs" },
-        { "o7", "chatsan-salutes" }
+        { "лол", "chatsan-laughs" },
+        { "o7", "chatsan-salutes" },
+        { "о7", "chatsan-salutes" } // cyrillic о
     };
 
     private bool doSanitize = false;

--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -35,6 +35,7 @@ public class ChatSanitizationManager : IChatSanitizationManager
         { ":D", "chatsan-smiles-widely" },
         { "D:", "chatsan-frowns-deeply" },
         { ":O", "chatsan-surprised" },
+        { ":О", "chatsan-surprised" },
         { ":3", "chatsan-smiles" }, //nope
         { ":S", "chatsan-uncertain" },
         { ":>", "chatsan-grins" },

--- a/Resources/Locale/ru-RU/chat/sanitizer-replacements.ftl
+++ b/Resources/Locale/ru-RU/chat/sanitizer-replacements.ftl
@@ -17,3 +17,4 @@ chatsan-surprised = выглядит удивленным
 chatsan-confused = выглядит смущенным
 chatsan-unimpressed = кажется не впечатлённым
 chatsan-waves = машет
+chatsan-salutes = отдаёт честь


### PR DESCRIPTION
## About the PR
Добавляет некоторые альтернативы эмотиконов в санитайзер.

**Screenshots**

**Changelog**

:cl: router
- add: Добавлено отдавание чести в конвертер эмодзи
- add: Некоторые эмодзи можно теперь вводить кириллицей ("о.о", "о7", ":о")
