### PR TITLE
Корректное отображения огней питания внешних шлюзов

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -17,10 +17,6 @@
       path: /Audio/Machines/airlock_deny.ogg
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/external.rsi
-  - type: Appearance
-    visuals:
-    - type: AirlockVisualizer
-    - type: WiresVisualizer
   - type: PaintableAirlock
     group: External
 


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

## Описание PR <!-- Опишите здесь ваш Pull Request. Что он изменяет? На что еще это может повлиять? -->
Исправление бага (упомянутого в https://github.com/ThetaStation/ThetaStation/pull/41) с отображением слоя огней питания для внешних шлюзов.

Причиной бага является то, что у прототип внешних шлюзов перезаписывал `AirlockVisualizer` его родителя. А `WiresVisualizer` был убран до кучи, так как тоже не имеет смысла его тут перезаписывать.

**Скриншоты**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->
![image](https://user-images.githubusercontent.com/14136326/180044731-b9cd022e-0777-4add-bf3f-161ed0bd68b8.png)

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.

Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: :cl: PJB

Как правило, в журналы изменений следует помещать только то, что действительно важно игрокам. Вещи вроде "Переработана система X, изменения не должны быть видны" не должны быть в журнале изменений.

При написании списка изменений не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров
-->

:cl: Morty
- fix: Исправлено отображения огней питания для внешних шлюзов

