### PR TITLE
Теперь HoS стартует с боевыми перчатками.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -29,6 +29,7 @@
     outerClothing: ClothingOuterCoatHoSTrench
     eyes: ClothingEyesGlassesSecurity
     head: ClothingHeadHatBeretHoS
+    gloves: ClothingHandsGlovesCombat
     id: HoSPDA
     ears: ClothingHeadsetAltSecurity
     belt: ClothingBeltSecurityFilled


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

## Описание PR
Изменены чуть-чуть строчки кода, которые добавляют HoS`у со старта раунда боевые перчатки.

:cl:
- add: боевые перчатки теперь у HoS`а с раунд старта.
