### PR TITLE
Небольшие изменения в голоде у животных

### DIFF
--- a/Content.Server/Nutrition/Components/HungerComponent.cs
+++ b/Content.Server/Nutrition/Components/HungerComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Nutrition.Components;
 using Robust.Shared.Random;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 
 namespace Content.Server.Nutrition.Components
 {
@@ -44,11 +45,14 @@ namespace Content.Server.Nutrition.Components
             get => _currentHunger;
             set => _currentHunger = value;
         }
-        private float _currentHunger;
+        [DataField("startingHunger")]
+        private float _currentHunger = -1f;
 
         [ViewVariables(VVAccess.ReadOnly)]
         public Dictionary<HungerThreshold, float> HungerThresholds => _hungerThresholds;
-        private readonly Dictionary<HungerThreshold, float> _hungerThresholds = new()
+
+        [DataField("thresholds", customTypeSerializer: typeof(DictionarySerializer<HungerThreshold, float>))]
+        private Dictionary<HungerThreshold, float> _hungerThresholds = new()
         {
             { HungerThreshold.Overfed, 200.0f },
             { HungerThreshold.Okay, 150.0f },
@@ -123,10 +127,15 @@ namespace Content.Server.Nutrition.Components
         protected override void Startup()
         {
             base.Startup();
-            // Similar functionality to SS13. Should also stagger people going to the chef.
-            _currentHunger = _random.Next(
-                (int)_hungerThresholds[HungerThreshold.Peckish] + 10,
-                (int)_hungerThresholds[HungerThreshold.Okay] - 1);
+            // Do not change behavior unless starting hunger is explicitly defined
+            if (_currentHunger < 0)
+            {
+                // Similar functionality to SS13. Should also stagger people going to the chef.
+                _currentHunger = _random.Next(
+                    (int) _hungerThresholds[HungerThreshold.Peckish] + 10,
+                    (int) _hungerThresholds[HungerThreshold.Okay] - 1);
+            }
+
             _currentHungerThreshold = GetHungerThreshold(_currentHunger);
             _lastHungerThreshold = HungerThreshold.Okay; // TODO: Potentially change this -> Used Okay because no effects.
             HungerThresholdEffect(true);

--- a/Content.Server/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Server/Nutrition/Components/ThirstComponent.cs
@@ -31,8 +31,10 @@ namespace Content.Server.Nutrition.Components
         public ThirstThreshold LastThirstThreshold;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float CurrentThirst;
+        [DataField("startingThirst")]
+        public float CurrentThirst = -1f;
 
+        [DataField("thresholds")]
         public Dictionary<ThirstThreshold, float> ThirstThresholds { get; } = new()
         {
             {ThirstThreshold.OverHydrated, 600.0f},

--- a/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
@@ -30,9 +30,13 @@ namespace Content.Server.Nutrition.EntitySystems
         }
         private void OnComponentStartup(EntityUid uid, ThirstComponent component, ComponentStartup args)
         {
-            component.CurrentThirst = _random.Next(
-                (int) component.ThirstThresholds[ThirstThreshold.Thirsty] + 10,
-                (int) component.ThirstThresholds[ThirstThreshold.Okay] - 1);
+            // Do not change behavior unless value is explicitly defined
+            if (component.CurrentThirst < 0)
+            {
+                component.CurrentThirst = _random.Next(
+                    (int) component.ThirstThresholds[ThirstThreshold.Thirsty] + 10,
+                    (int) component.ThirstThresholds[ThirstThreshold.Okay] - 1);
+            }
             component.CurrentThirstThreshold = GetThirstThreshold(component, component.CurrentThirst);
             component.LastThirstThreshold = ThirstThreshold.Okay; // TODO: Potentially change this -> Used Okay because no effects.
             // TODO: Check all thresholds make sense and throw if they don't.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1373,6 +1373,13 @@
   - type: Grammar
     attributes:
       gender: epicene
+  - type: Hunger
+    hunger-thresholds:
+      Overfed: 199
+      Okay: 150
+      Peckish: 100
+      Starving: 50
+      Dead: 10
 
 - type: entity
   name: raccoon

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -50,6 +50,22 @@
         Piercing: 8
   - type: Body
     prototype: Rat
+  - type: Hunger # probably should be prototyped
+    thresholds:
+      Overfed: 200
+      Okay: 150
+      Peckish: 100
+      Starving: 50
+      Dead: 0
+    baseDecayRate: 0.01666666666
+  - type: Thrist
+    thresholds:
+      OverHydrated: 600
+      Okay: 450
+      Thirsty: 300
+      Parched: 150
+      Dead: 0
+    baseDecayRate: 0.1
   - type: Appearance
   - type: DamageStateVisuals
     rotate: true
@@ -209,6 +225,21 @@
         Piercing: 3
   - type: Body
     prototype: Rat
+  - type: Hunger
+    thresholds:
+      Overfed: 200
+      Okay: 150
+      Peckish: 100
+      Starving: 50
+      Dead: 0
+  - type: Thrist
+    thresholds:
+      OverHydrated: 600
+      Okay: 450
+      Thirsty: 300
+      Parched: 150
+      Dead: 0
+    base-decay-rate: 0.01666666666
   - type: Appearance
   - type: DamageStateVisuals
     rotate: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -163,7 +163,21 @@
   - type: InputMover
   - type: MobMover
   - type: Hunger
+    thresholds: # only animals and rats are derived from this prototype so let's override it here and in rats' proto
+      Overfed: 100
+      Okay: 50
+      Peckish: 25
+      Starving: 10
+      Dead: 0
+    baseDecayRate: 0,00925925925926 # it is okay for animals to eat and drink less than humans, but more frequently
   - type: Thirst
+    thresholds:
+      OverHydrated: 200
+      Okay: 150
+      Thirsty: 100
+      Parched: 50
+      Dead: 0
+    baseDecayRate: 0.04
   - type: Barotrauma
     damage:
       types:


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

## Описание PR <!-- Опишите здесь ваш Pull Request. Что он изменяет? На что еще это может повлиять? -->
После пары игр на разумных животных мне очень не понравилось, что у них невероятно маленький желудок, а потребности в еде такие же, как и у остальных существ в игре. Добавил возможность настраивать пороги голода и жажды через YAML-файлы, а также стартовые их значения. Поменял цифры скорости голодания и их порогов у предка всех животных на, как мне кажется, более подходящие. У крыс вручную указал обычные, так как они должны выполнять свою роль. 
**Скриншоты**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.

Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: :cl: PJB

Как правило, в журналы изменений следует помещать только то, что действительно важно игрокам. Вещи вроде "Переработана система X, изменения не должны быть видны" не должны быть в журнале изменений.

При написании списка изменений не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров
-->

:cl: Prentor
- tweak: животные теперь едят меньше, но чаще.

