### PR TITLE
Fix round end notification

### DIFF
--- a/Content.Server/Corvax/GameTicking/RoundEndedEvent.cs
+++ b/Content.Server/Corvax/GameTicking/RoundEndedEvent.cs
@@ -1,0 +1,13 @@
+﻿namespace Content.Shared.GameTicking;
+
+public sealed class RoundEndedEvent : EntityEventArgs
+{
+    public int RoundId { get; }
+    public TimeSpan RoundDuration { get; }
+
+    public RoundEndedEvent(int roundId, TimeSpan roundDuration)
+    {
+        RoundId = roundId;
+        RoundDuration = roundDuration;
+    }
+}

--- a/Content.Server/Corvax/GameTicking/RoundStartedEvent.cs
+++ b/Content.Server/Corvax/GameTicking/RoundStartedEvent.cs
@@ -1,12 +1,11 @@
-﻿namespace Content.Shared.GameTicking
+﻿namespace Content.Shared.GameTicking;
+
+public sealed class RoundStartedEvent : EntityEventArgs
 {
-    public sealed class RoundStartedEvent : EntityEventArgs
+    public int RoundId { get; }
+    
+    public RoundStartedEvent(int roundId)
     {
-        public int RoundId { get; }
-        
-        public RoundStartedEvent(int roundId)
-        {
-            RoundId = roundId;
-        }
+        RoundId = roundId;
     }
 }

--- a/Content.Server/Corvax/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Corvax/RoundNotifications/RoundNotificationsSystem.cs
@@ -29,7 +29,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
     {
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
         SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
-        SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
 
         _config.OnValueChanged(CCCVars.DiscordRoundWebhook, value => _discordWebhook = value, true);
         _config.OnValueChanged(CCCVars.DiscordRoundRoleId, value => _discordRoleId = value, true);
@@ -77,7 +77,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
         SendDiscordMessage(payload);
     }
     
-    private void OnRoundEnd(RoundEndMessageEvent e)
+    private void OnRoundEnded(RoundEndedEvent e)
     {
         if (String.IsNullOrEmpty(_discordWebhook))
             return;

--- a/Content.Server/Corvax/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Corvax/RoundNotifications/RoundNotificationsSystem.cs
@@ -3,7 +3,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Content.Server.Maps;
-using Content.Shared.CCVar;
 using Content.Shared.Corvax.CCCVars;
 using Content.Shared.GameTicking;
 using Robust.Shared.Configuration;
@@ -21,9 +20,9 @@ public sealed class RoundNotificationsSystem : EntitySystem
     private ISawmill _sawmill = default!;
     private readonly HttpClient _httpClient = new();
     
-    private string _discordWebhook = String.Empty;
-    private string _discordRoleId = String.Empty;
-    private bool _discordRoundStartOnly = false;
+    private string _webhookUrl = String.Empty;
+    private string _roleId = String.Empty;
+    private bool _roundStartOnly;
     
     /// <inheritdoc/>
     public override void Initialize()
@@ -32,16 +31,16 @@ public sealed class RoundNotificationsSystem : EntitySystem
         SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
         SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
 
-        _config.OnValueChanged(CCCVars.DiscordRoundWebhook, value => _discordWebhook = value, true);
-        _config.OnValueChanged(CCCVars.DiscordRoundRoleId, value => _discordRoleId = value, true);
-        _config.OnValueChanged(CCCVars.DiscordRoundStartOnly, value => _discordRoundStartOnly = value, true);
+        _config.OnValueChanged(CCCVars.DiscordRoundWebhook, value => _webhookUrl = value, true);
+        _config.OnValueChanged(CCCVars.DiscordRoundRoleId, value => _roleId = value, true);
+        _config.OnValueChanged(CCCVars.DiscordRoundStartOnly, value => _roundStartOnly = value, true);
 
         _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("notifications");
     }
 
     private void OnRoundRestart(RoundRestartCleanupEvent e)
     {
-        if (String.IsNullOrEmpty(_discordWebhook))
+        if (String.IsNullOrEmpty(_webhookUrl))
             return;
 
         var payload = new WebhookPayload()
@@ -49,14 +48,14 @@ public sealed class RoundNotificationsSystem : EntitySystem
             Content = Loc.GetString("discord-round-new"),
         };
 
-        if (!String.IsNullOrEmpty(_discordRoleId))
+        if (!String.IsNullOrEmpty(_roleId))
         {
             payload = new WebhookPayload()
             {
-                Content = $"<@&{_discordRoleId}> {Loc.GetString("discord-round-new")}",
+                Content = $"<@&{_roleId}> {Loc.GetString("discord-round-new")}",
                 AllowedMentions = new Dictionary<string, string[]>
                 {
-                    { "roles", new []{ _discordRoleId } }
+                    { "roles", new []{ _roleId } }
                 },
             };
         }
@@ -66,7 +65,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
 
     private void OnRoundStarted(RoundStartedEvent e)
     {
-        if (String.IsNullOrEmpty(_discordWebhook))
+        if (String.IsNullOrEmpty(_webhookUrl))
             return;
 
         var map = _gameMapManager.GetSelectedMap();
@@ -81,7 +80,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
     
     private void OnRoundEnded(RoundEndedEvent e)
     {
-        if (String.IsNullOrEmpty(_discordWebhook) || _discordRoundStartOnly)
+        if (String.IsNullOrEmpty(_webhookUrl) || _roundStartOnly)
             return;
 
         var text = Loc.GetString("discord-round-end",
@@ -96,7 +95,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
 
     private async void SendDiscordMessage(WebhookPayload payload)
     {
-        var request = await _httpClient.PostAsync(_discordWebhook,
+        var request = await _httpClient.PostAsync(_webhookUrl,
             new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
 
         var content = await request.Content.ReadAsStringAsync();

--- a/Content.Server/Corvax/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Corvax/RoundNotifications/RoundNotificationsSystem.cs
@@ -23,6 +23,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
     
     private string _discordWebhook = String.Empty;
     private string _discordRoleId = String.Empty;
+    private bool _discordRoundStartOnly = false;
     
     /// <inheritdoc/>
     public override void Initialize()
@@ -33,6 +34,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
 
         _config.OnValueChanged(CCCVars.DiscordRoundWebhook, value => _discordWebhook = value, true);
         _config.OnValueChanged(CCCVars.DiscordRoundRoleId, value => _discordRoleId = value, true);
+        _config.OnValueChanged(CCCVars.DiscordRoundStartOnly, value => _discordRoundStartOnly = value, true);
 
         _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("notifications");
     }
@@ -79,7 +81,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
     
     private void OnRoundEnded(RoundEndedEvent e)
     {
-        if (String.IsNullOrEmpty(_discordWebhook))
+        if (String.IsNullOrEmpty(_discordWebhook) || _discordRoundStartOnly)
             return;
 
         var text = Loc.GetString("discord-round-end",

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -372,6 +372,7 @@ namespace Content.Server.GameTicking
             RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, RoundId,
                 listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal, LobbySong,
                 new SoundCollectionSpecifier("RoundEnd").GetSound()));
+            RaiseLocalEvent(new RoundEndedEvent(RoundId, roundDuration)); // Corvax-RoundNotifications
         }
 
         public void RestartRound()

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -245,11 +245,8 @@ namespace Content.Server.GameTicking
             UpdateLateJoinStatus();
             AnnounceRound();
             UpdateInfoText();
+            RaiseLocalEvent(new RoundStartedEvent(RoundId)); // Corvax-RoundNotifications
 
-            // Corvax-RoundNotifications-Start
-            var roundStartedEvent = new RoundStartedEvent(RoundId);
-            RaiseLocalEvent(roundStartedEvent);
-            // Corvax-RoundNotifications-End
 #if EXCEPTION_TOLERANCE
             }
             catch (Exception e)

--- a/Content.Shared/Corvax/CCCVars/CCCVars.cs
+++ b/Content.Shared/Corvax/CCCVars/CCCVars.cs
@@ -25,6 +25,12 @@ public sealed class CCCVars
     public static readonly CVarDef<string> DiscordRoundRoleId =
         CVarDef.Create("discord.round_roleid", string.Empty, CVar.SERVERONLY);
 
+    /// <summary>
+    ///     Send notifications only about a new round begins.
+    /// </summary>
+    public static readonly CVarDef<bool> DiscordRoundStartOnly =
+        CVarDef.Create("discord.round_start_only", false, CVar.SERVERONLY);
+
     /**
      * Sponsors
      */


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
Уведомление об окончании раунда перестало отправляться так как оно сетевое, пришлось создать упрощённое событие `RoundEndedEvent` (по аналогии уже с нашим `RoundStartedEvent`) и делать `RaiseLocalEvent`. Так же имеется настройка для отключения уведомлений об окончании раунда.

**Скриншоты**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Поддерживается 4 типа значков: add, remove, tweak, fix. Выбрать правильные не должно составить для вас труда.

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

В журнал изменений следует помещать только то, что действительно важно игрокам. Вещи вроде "Рефакторинг системы X" не должны быть в журнале изменений.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров
-->

:cl: Morty
- fix: Уведомления об окончании раунда теперь доходят
