### PR TITLE
Fixed IAA briefcase suffix

### DIFF
--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/corvax/catalog/fills/items/briefcases.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/corvax/catalog/fills/items/briefcases.ftl
@@ -1,3 +1,3 @@
 ent-BriefcaseIAAFilled = { ent-BriefcaseBrown }
-    .suffix = Заполненный
+    .suffix = АВД
     .desc = { ent-BriefcaseBrown.desc }

--- a/Resources/Prototypes/Corvax/Catalog/Fills/Items/briefcases.yml
+++ b/Resources/Prototypes/Corvax/Catalog/Fills/Items/briefcases.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BriefcaseIAAFilled
   parent: BriefcaseBrown
-  suffix: Filled
+  suffix: IAA
   components:
     - type: StorageFill
       contents:


### PR DESCRIPTION
Маленькая правка suffix чемоданчика АВД. При маппинге очень легко перепутать:
![image](https://user-images.githubusercontent.com/107036969/228494622-e5f23d42-ac32-49f5-8497-ba392d0c1ab1.png)