### PR TITLE
Замена руководителей профессий v2

### DIFF
--- a/Resources/Locale/en-US/corvax/job/job-supervisors.ftl
+++ b/Resources/Locale/en-US/corvax/job/job-supervisors.ftl
@@ -1,0 +1,15 @@
+﻿job-supervisors-centcom = CentCom official
+job-supervisors-captain = the captain
+job-supervisors-hop = the head of personnel
+job-supervisors-hop-qm = the quartermaster and head of personnel
+job-supervisors-hos = the head of security
+job-supervisors-ce = the chief engineer
+job-supervisors-cmo = the chief medical officer
+job-supervisors-rd = the research director
+job-supervisors-service = chefs, botanists, the bartender, and the head of personnel
+job-supervisors-engineering = station engineers, atmospheric technicians, and the chief engineer
+job-supervisors-medicine = medical doctors, chemists, and the chief medical officer
+job-supervisors-security = security officers, the warden, and the head of security
+job-supervisors-hire = whoever hires you
+job-supervisors-everyone = absolutely everyone
+job-supervisors-qm = the quartermaster

--- a/Resources/Locale/en-US/corvax/job/job-supervisors.ftl
+++ b/Resources/Locale/en-US/corvax/job/job-supervisors.ftl
@@ -1,15 +1,1 @@
-﻿job-supervisors-centcom = CentCom official
-job-supervisors-captain = the captain
-job-supervisors-hop = the head of personnel
-job-supervisors-hop-qm = the quartermaster and head of personnel
-job-supervisors-hos = the head of security
-job-supervisors-ce = the chief engineer
-job-supervisors-cmo = the chief medical officer
-job-supervisors-rd = the research director
-job-supervisors-service = chefs, botanists, the bartender, and the head of personnel
-job-supervisors-engineering = station engineers, atmospheric technicians, and the chief engineer
-job-supervisors-medicine = medical doctors, chemists, and the chief medical officer
-job-supervisors-security = security officers, the warden, and the head of security
-job-supervisors-hire = whoever hires you
-job-supervisors-everyone = absolutely everyone
-job-supervisors-qm = the quartermaster
+﻿job-supervisors-qm = the quartermaster

--- a/Resources/Locale/ru-RU/corvax/job/job-supervisors.ftl
+++ b/Resources/Locale/ru-RU/corvax/job/job-supervisors.ftl
@@ -1,0 +1,15 @@
+job-supervisors-centcom = представителю Центкома
+job-supervisors-captain = капитану
+job-supervisors-hop = главе персонала
+job-supervisors-hop-qm = квартирмейстеру и главе персонала
+job-supervisors-hos = главе службы безопасности
+job-supervisors-ce = старшему инженеру
+job-supervisors-cmo = главному врачу
+job-supervisors-rd = научному руководителю
+job-supervisors-service = поварам, ботаникам, барменам, и главе персонала
+job-supervisors-engineering = инженерам, атмосферным техникам, и старшему инженеру
+job-supervisors-medicine = врачам, химикам, и главному врачу
+job-supervisors-security = офицерам, смотрителю, и главе службы безопасности
+job-supervisors-hire = своим нанимателям
+job-supervisors-everyone = вообще всем
+job-supervisors-qm = квартирмейстеру

--- a/Resources/Locale/ru-RU/corvax/job/job-supervisors.ftl
+++ b/Resources/Locale/ru-RU/corvax/job/job-supervisors.ftl
@@ -1,15 +1,1 @@
-job-supervisors-centcom = представителю Центкома
-job-supervisors-captain = капитану
-job-supervisors-hop = главе персонала
-job-supervisors-hop-qm = квартирмейстеру и главе персонала
-job-supervisors-hos = главе службы безопасности
-job-supervisors-ce = старшему инженеру
-job-supervisors-cmo = главному врачу
-job-supervisors-rd = научному руководителю
-job-supervisors-service = поварам, ботаникам, барменам, и главе персонала
-job-supervisors-engineering = инженерам, атмосферным техникам, и старшему инженеру
-job-supervisors-medicine = врачам, химикам, и главному врачу
-job-supervisors-security = офицерам, смотрителю, и главе службы безопасности
-job-supervisors-hire = своим нанимателям
-job-supervisors-everyone = вообще всем
 job-supervisors-qm = квартирмейстеру

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobCargoTechnician
   startingGear: CargoTechGear
   icon: "CargoTechnician"
-  supervisors: job-supervisors-hop-qm
+  supervisors: job-supervisors-qm # Corvax-JobSupervisors
   access:
   - Cargo
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -15,7 +15,7 @@
   weight: 10
   startingGear: QuartermasterGear
   icon: "QuarterMaster"
-  supervisors: job-supervisors-hop
+  supervisors: job-supervisors-captain # Corvax-JobSupervisors
   canBeAntag: false
   access:
   - Cargo

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -9,7 +9,7 @@
       time: 10800 # Corvax-RoleTime
   icon: "ShaftMiner"
   startingGear: SalvageSpecialistGear
-  supervisors: job-supervisors-hop-qm
+  supervisors: job-supervisors-qm # Corvax-JobSupervisors
   access:
   - Cargo
   - Salvage

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobPassenger
   startingGear: PassengerGear
   icon: "Passenger"
-  supervisors: job-supervisors-everyone
+  supervisors: job-supervisors-hop # Corvax-JobSupervisors
 #  access: # Corvax
 #  - Maintenance
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobMusician
   startingGear: MusicianGear
   icon: "Musician"
-  supervisors: job-supervisors-hire
+  supervisors: job-supervisors-hop # Corvax-JobSupervisors
   access:
   - Maintenance # TODO Remove maint access for all gimmick jobs once access work is completed
   - Theatre

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -6,7 +6,7 @@
   setPreference: false
   startingGear: CentcomGear
   icon: "Nanotrasen"
-  supervisors: job-supervisors-hos
+  supervisors: job-supervisors-centcom # Corvax-JobSupervisors
   canBeAntag: false
   accessGroups:
   - AllAccess


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Несмотря на все разработки своего лора, вики, и подобного, у нас всё это время оставалось описание профессий официального сервера. Из-за чего у нас:
- Квартирмейстер не был полноценным главой, а подчинялся ГП; (теперь подчиняется кэпу и глава)
- Весь состав карго подчинялся КМу И ГП; (теперь подчиняются только КМу)
- Представитель Центрального Командования непонятно почему подчинялся Главе Службы Безопасности станции; (Теперь подчиняется только ЦК)
- Музыкант не находился в сервисе по подчинённости, хотя по всем признакам именно там и находился; (теперь в сервисе, глава - ГП)
- Пассажир подчинялся всем на станции (теперь глава ГП)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl:
- tweak: Центральное Командование исправило ошибку в манифесте и перестало указывать Квартирмейстера в подчинении Главе Персонала.
