### PR TITLE
Terms support for locale scripts

### DIFF
--- a/Tools/ss14_ru/fluentast.py
+++ b/Tools/ss14_ru/fluentast.py
@@ -13,6 +13,8 @@ class FluentAstAbstract:
             return FluentAstJunk(element).get_id_name()
         elif isinstance(element, ast.Message):
             return FluentAstMessage(element).get_id_name()
+        elif isinstance(element, ast.Term):
+            return FluentAstTerm(element).get_id_name()
         else:
             return None
 
@@ -23,6 +25,9 @@ class FluentAstAbstract:
             return cls.element
         elif isinstance(element, ast.Message):
             cls.element = FluentAstMessage(element)
+            return cls.element
+        elif isinstance(element, ast.Term):
+            cls.element = FluentAstTerm(element)
             return cls.element
         else:
             return None
@@ -35,6 +40,16 @@ class FluentAstMessage:
 
     def get_id_name(self):
         return self.message.id.name
+
+
+class FluentAstTerm:
+    def __init__(self, term: ast.Term):
+        self.term = term
+        self.element = term
+
+    def get_id_name(self):
+        return self.term.id.name
+
 
 
 class FluentAstAttribute:

--- a/Tools/ss14_ru/fluentast.py
+++ b/Tools/ss14_ru/fluentast.py
@@ -51,7 +51,6 @@ class FluentAstTerm:
         return self.term.id.name
 
 
-
 class FluentAstAttribute:
     def __init__(self, id, value, parent_key = None):
         self.id = id


### PR DESCRIPTION
Terms теперь не игнорируются скриптом и не высвечиваются как `None`, что приводило к таким проблемам, как дублирование строки с каждым запуском `keyfinder.py`
