### PR TITLE
Fix stuff

### DIFF
--- a/Resources/Locale/ru-RU/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/ru-RU/guidebook/chemistry/conditions.ftl
@@ -39,7 +39,7 @@ reagent-effect-condition-guidebook-organ-type =
     метаболизирующий орган { $shouldhave ->
         [true] это
        *[false] это не
-    } { INDEFINITE($name) } { $name } орган
+    } { $name } { $name } орган
 reagent-effect-condition-guidebook-has-tag =
     цель { $invert ->
         [true] не имеет

--- a/Resources/Locale/ru-RU/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/ru-RU/guidebook/chemistry/conditions.ftl
@@ -39,7 +39,7 @@ reagent-effect-condition-guidebook-organ-type =
     метаболизирующий орган { $shouldhave ->
         [true] это
        *[false] это не
-    } { $name } { $name } орган
+    } { $name } орган
 reagent-effect-condition-guidebook-has-tag =
     цель { $invert ->
         [true] не имеет

--- a/Resources/Locale/ru-RU/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/ru-RU/guidebook/chemistry/effects.ftl
@@ -18,7 +18,7 @@ reagent-effect-guidebook-create-entity-reaction-effect =
         [1] Создаёт
        *[other] создают
     } { $amount ->
-        [1] { INDEFINITE($entname) }
+        [1] { $entname }
        *[other] { $amount } { $entname }
     }
 reagent-effect-guidebook-explosion-reaction-effect =

--- a/Resources/Locale/ru-RU/medical/components/cryo-pod-component.ftl
+++ b/Resources/Locale/ru-RU/medical/components/cryo-pod-component.ftl
@@ -1,7 +1,7 @@
 # Ejection verb label.
 cryo-pod-verb-noun-occupant = Пациент
 # Examine text showing whether there's a beaker in the pod and if it is empty.
-cryo-pod-examine = Здесь находится { INDEFINITE($beaker) } { $beaker }.
+cryo-pod-examine = Здесь находится { $beaker } { $beaker }.
 cryo-pod-empty-beaker = Тут пусто!
 # Shown when a normal ejection through the eject verb is attempted on a locked pod.
 cryo-pod-locked = Механизм извлечения не реагирует!

--- a/Resources/Locale/ru-RU/medical/components/cryo-pod-component.ftl
+++ b/Resources/Locale/ru-RU/medical/components/cryo-pod-component.ftl
@@ -1,7 +1,7 @@
 # Ejection verb label.
 cryo-pod-verb-noun-occupant = Пациент
 # Examine text showing whether there's a beaker in the pod and if it is empty.
-cryo-pod-examine = Здесь находится { $beaker } { $beaker }.
+cryo-pod-examine = Здесь находится { $beaker }.
 cryo-pod-empty-beaker = Тут пусто!
 # Shown when a normal ejection through the eject verb is attempted on a locked pod.
 cryo-pod-locked = Механизм извлечения не реагирует!


### PR DESCRIPTION
из ру локали убрана функция `INDEFINITE`, которая устанавливает неопределенный артикль `a`/`an`
https://github.com/space-wizards/RobustToolbox/blob/1009dd3ea0e98b9d0715314fc4f5b14c11833398/Robust.Shared/Localization/LocalizationManager.Functions.cs#L85