### PR TITLE
Outpost Update

### DIFF
--- a/Resources/Maps/corvax_outpost.yml
+++ b/Resources/Maps/corvax_outpost.yml
@@ -304,7 +304,7 @@ entities:
           version: 6
         -3,2:
           ind: -3,2
-          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAAFFgAAAAAAFgAAAAAFeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAABFgAAAAAFeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAAEeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAA
+          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAAFFgAAAAAAFgAAAAAFeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAABFgAAAAAFeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAAEeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAA
           version: 6
         -2,2:
           ind: -2,2
@@ -328,7 +328,7 @@ entities:
           version: 6
         -4,2:
           ind: -4,2
-          tiles: IgAAAAABIgAAAAADIgAAAAADIgAAAAADIgAAAAACeQAAAAAAFgAAAAABFgAAAAADFgAAAAADFgAAAAAAFgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAACFgAAAAAFFgAAAAAGFgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAFgAAAAAEFgAAAAADFgAAAAAGFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAAFgAAAAAGFgAAAAAAFgAAAAACFgAAAAAGFgAAAAACFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAADwAAAAAAFgAAAAABDwAAAAAAFgAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAAFgAAAAADFgAAAAACDwAAAAAAFgAAAAADDwAAAAAAFgAAAAAFeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAAGFgAAAAAEFgAAAAAAFgAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAACFgAAAAAADwAAAAAADwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAAFgAAAAAADwAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAADwAAAAAAFgAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAADwAAAAAAFgAAAAABDwAAAAAAFgAAAAAAFgAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAADwAAAAAADwAAAAAAFgAAAAAAFgAAAAADFgAAAAABFgAAAAAAFgAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAAFgAAAAABFgAAAAAAFgAAAAAGFgAAAAAGFgAAAAADeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAAFgAAAAADFgAAAAABFgAAAAABFgAAAAABFgAAAAAEFgAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAADFgAAAAABFgAAAAABFgAAAAACFgAAAAADFgAAAAACFgAAAAAEeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAAAAEFgAAAAAGFgAAAAADFgAAAAAGeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAA
+          tiles: IgAAAAABIgAAAAADIgAAAAADIgAAAAADIgAAAAACeQAAAAAAFgAAAAABFgAAAAADFgAAAAADFgAAAAAAFgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAACFgAAAAAFFgAAAAAGFgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAFgAAAAAEFgAAAAADFgAAAAAGFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAADwAAAAAADwAAAAAAFgAAAAAGFgAAAAAAFgAAAAACFgAAAAAGFgAAAAACFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAADwAAAAAAFgAAAAABDwAAAAAAFgAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAADwAAAAAAFgAAAAADFgAAAAACDwAAAAAAFgAAAAADDwAAAAAAFgAAAAAFeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAFgAAAAAGFgAAAAAEFgAAAAAAFgAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAACFgAAAAAADwAAAAAADwAAAAAAFgAAAAAAFgAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAAFgAAAAAADwAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAADwAAAAAAFgAAAAAAFgAAAAAADwAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAADwAAAAAAFgAAAAABDwAAAAAAFgAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAADwAAAAAADwAAAAAAFgAAAAAAFgAAAAADFgAAAAABFgAAAAAAFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAADwAAAAAAFgAAAAABFgAAAAAAFgAAAAAGFgAAAAAGFgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADwAAAAAAFgAAAAADFgAAAAABFgAAAAABFgAAAAABFgAAAAAEFgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAFgAAAAADFgAAAAABFgAAAAABFgAAAAACFgAAAAADFgAAAAACFgAAAAAEeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAAAAEFgAAAAAGFgAAAAADFgAAAAAGeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAA
           version: 6
         -4,1:
           ind: -4,1
@@ -1844,8 +1844,8 @@ entities:
             color: '#FF0000FF'
             id: BrickTileWhiteLineN
           decals:
-            4841: -45,30
-            4842: -44,30
+            4838: -45,30
+            4839: -44,30
         - node:
             color: '#FFFFFFFF'
             id: BrickTileWhiteLineN
@@ -1887,8 +1887,8 @@ entities:
             color: '#FF0000FF'
             id: BrickTileWhiteLineS
           decals:
-            4843: -44,32
-            4844: -45,32
+            4840: -44,32
+            4841: -45,32
         - node:
             color: '#FFFFFFFF'
             id: BrickTileWhiteLineS
@@ -2463,9 +2463,9 @@ entities:
             46: 17,-10
             47: 17,-9
             66: 19,-6
-            4933: 0,-38
-            4934: 0,-37
-            4935: 0,-36
+            4858: 0,-38
+            4859: 0,-37
+            4860: 0,-36
         - node:
             color: '#FFFFFFFF'
             id: Dirt
@@ -4788,6 +4788,8 @@ entities:
             id: WarnLineW
           decals:
             690: 20,14
+            4920: -53,37
+            4921: -49,37
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
@@ -5294,43 +5296,43 @@ entities:
             color: '#331F136D'
             id: splatter
           decals:
-            4985: -0.28932428,-38.236748
-            4986: -0.7729883,-38.55159
-            4987: -0.019371986,-36.628803
+            4910: -0.28932428,-38.236748
+            4911: -0.7729883,-38.55159
+            4912: -0.019371986,-36.628803
         - node:
             color: '#3F27176D'
             id: splatter
           decals:
-            4963: -0.23518214,-37.275463
-            4964: -0.41515064,-38.130035
-            4965: -0.58386964,-38.422386
-            4966: -0.32516575,-38.669765
-            4967: -1.0562856,-38.61354
-            4968: -1.2475011,-38.96212
-            4969: -0.52762955,-38.928387
-            4970: -0.40390238,-38.287457
-            4971: -0.0075728893,-36.394268
-            4972: -0.24378145,-35.68587
-            4973: -0.4125017,-35.359787
-            4974: 0.03741896,-36.55169
-            4975: -0.030069351,-37.496216
-            4976: -1.8067163,-37.40976
-            4977: -1.5142677,-37.578423
-            4978: -1.6942362,-37.40976
-            4979: -1.4130359,-35.576923
-            4980: -1.0306048,-35.419502
-            4981: -1.2780604,-35.633144
-            4982: -1.581756,-35.7231
-            4983: -2.3578677,-36.80256
-            4984: -2.335371,-37.342293
+            4888: -0.23518214,-37.275463
+            4889: -0.41515064,-38.130035
+            4890: -0.58386964,-38.422386
+            4891: -0.32516575,-38.669765
+            4892: -1.0562856,-38.61354
+            4893: -1.2475011,-38.96212
+            4894: -0.52762955,-38.928387
+            4895: -0.40390238,-38.287457
+            4896: -0.0075728893,-36.394268
+            4897: -0.24378145,-35.68587
+            4898: -0.4125017,-35.359787
+            4899: 0.03741896,-36.55169
+            4900: -0.030069351,-37.496216
+            4901: -1.8067163,-37.40976
+            4902: -1.5142677,-37.578423
+            4903: -1.6942362,-37.40976
+            4904: -1.4130359,-35.576923
+            4905: -1.0306048,-35.419502
+            4906: -1.2780604,-35.633144
+            4907: -1.581756,-35.7231
+            4908: -2.3578677,-36.80256
+            4909: -2.335371,-37.342293
         - node:
             color: '#41230F6D'
             id: splatter
           decals:
-            4959: -0.6678871,-38.20683
-            4960: -0.29670304,-36.778793
-            4961: -0.38668793,-37.363503
-            4962: -0.4654233,-35.541912
+            4884: -0.6678871,-38.20683
+            4885: -0.29670304,-36.778793
+            4886: -0.38668793,-37.363503
+            4887: -0.4654233,-35.541912
         - node:
             cleanable: True
             color: '#440900FF'
@@ -7028,61 +7030,61 @@ entities:
             color: '#4727116D'
             id: splatter
           decals:
-            4918: -0.6003987,-38.341763
-            4919: -0.4654233,-37.9707
-            4920: -0.84785557,-38.487938
-            4921: -0.4091832,-38.12812
-            4922: -0.52166337,-38.341763
-            4923: -0.454175,-37.48719
-            4924: -0.49916685,-36.182842
-            4925: -0.5104151,-36.801285
-            4926: -0.6903836,-35.699333
-            4927: -0.53291166,-35.631866
-            4928: -0.47667158,-35.40698
-            4929: -0.57790345,-36.059155
-            4930: -0.4654233,-37.02617
-            4931: -0.58915174,-37.779545
-            4932: -0.47667158,-36.385242
-            4936: -0.611647,-38.173096
-            4937: -0.29670304,-38.02692
-            4938: -0.29670304,-38.487938
-            4939: -0.74662375,-38.397984
-            4940: -0.3641914,-38.397984
-            4941: -0.30795133,-36.497684
-            4942: -0.30795133,-37.599632
-            4943: -0.35294312,-36.969948
-            4944: -0.47667158,-35.81178
-            4945: -0.4091832,-35.53067
-            4946: -0.4091832,-35.260803
-            4947: -0.12798405,-35.575645
-            4948: -0.454175,-35.474445
-            4949: 0.018239617,-35.676846
-            4950: -0.28545606,-35.53067
-            4951: -0.25171125,-36.598885
-            4952: -0.5441599,-36.04791
-            4953: -0.33044785,-36.969948
-            4954: -0.7578707,-37.880745
-            4955: -0.6453918,-36.79004
+            4843: -0.6003987,-38.341763
+            4844: -0.4654233,-37.9707
+            4845: -0.84785557,-38.487938
+            4846: -0.4091832,-38.12812
+            4847: -0.52166337,-38.341763
+            4848: -0.454175,-37.48719
+            4849: -0.49916685,-36.182842
+            4850: -0.5104151,-36.801285
+            4851: -0.6903836,-35.699333
+            4852: -0.53291166,-35.631866
+            4853: -0.47667158,-35.40698
+            4854: -0.57790345,-36.059155
+            4855: -0.4654233,-37.02617
+            4856: -0.58915174,-37.779545
+            4857: -0.47667158,-36.385242
+            4861: -0.611647,-38.173096
+            4862: -0.29670304,-38.02692
+            4863: -0.29670304,-38.487938
+            4864: -0.74662375,-38.397984
+            4865: -0.3641914,-38.397984
+            4866: -0.30795133,-36.497684
+            4867: -0.30795133,-37.599632
+            4868: -0.35294312,-36.969948
+            4869: -0.47667158,-35.81178
+            4870: -0.4091832,-35.53067
+            4871: -0.4091832,-35.260803
+            4872: -0.12798405,-35.575645
+            4873: -0.454175,-35.474445
+            4874: 0.018239617,-35.676846
+            4875: -0.28545606,-35.53067
+            4876: -0.25171125,-36.598885
+            4877: -0.5441599,-36.04791
+            4878: -0.33044785,-36.969948
+            4879: -0.7578707,-37.880745
+            4880: -0.6453918,-36.79004
         - node:
             color: '#522C136D'
             id: splatter
           decals:
-            4956: -0.37543964,-38.195587
-            4957: -1.0278229,-38.757805
-            4958: -0.4091832,-38.341763
+            4881: -0.37543964,-38.195587
+            4882: -1.0278229,-38.757805
+            4883: -0.4091832,-38.341763
         - node:
             color: '#542D146D'
             id: splatter
           decals:
-            4902: -1.268822,-38.74215
+            4842: -1.268822,-38.74215
         - node:
             color: '#54341F6D'
             id: splatter
           decals:
-            4988: -0.1431005,-38.16928
-            4989: -0.008125067,-37.41591
-            4990: 0.11560345,-36.347694
-            4991: -0.28932428,-36.403915
+            4913: -0.1431005,-38.16928
+            4914: -0.008125067,-37.41591
+            4915: 0.11560345,-36.347694
+            4916: -0.28932428,-36.403915
         - node:
             cleanable: True
             color: '#7915004B'
@@ -7675,7 +7677,8 @@ entities:
             0: 57343
             6: 8192
           -12,3:
-            0: 64989
+            0: 64861
+            8: 128
             6: 546
           -11,0:
             0: 65535
@@ -7754,7 +7757,7 @@ entities:
             0: 65535
           0,-12:
             0: 32767
-            8: 32768
+            9: 32768
           1,-12:
             0: 65535
           1,-11:
@@ -7871,14 +7874,14 @@ entities:
             0: 49151
           -1,-15:
             0: 4096
-            9: 76
+            10: 76
           -1,-14:
             0: 8994
           -1,-13:
             0: 35378
           0,-15:
             0: 65518
-            9: 1
+            10: 1
           0,-14:
             0: 65535
           0,-13:
@@ -7895,7 +7898,7 @@ entities:
             0: 65535
           2,-16:
             0: 63487
-            10: 2048
+            11: 2048
           2,-15:
             0: 65535
           2,-14:
@@ -7939,35 +7942,35 @@ entities:
             0: 13072
           7,-15:
             0: 30579
-            9: 128
+            10: 128
           7,-14:
             0: 65535
           7,-13:
             0: 65535
           0,-17:
             0: 32768
-            9: 8
+            10: 8
           1,-17:
             0: 64512
-            9: 275
+            10: 275
           2,-17:
             0: 65528
           3,-17:
             0: 65535
           3,-18:
             0: 49152
-            9: 2188
+            10: 2188
           4,-18:
             0: 4096
-            9: 1
+            10: 1
           4,-17:
             0: 65527
           5,-17:
             0: 65296
-            9: 8
+            10: 8
           6,-17:
             0: 12288
-            9: 275
+            10: 275
           8,-12:
             0: 65535
           8,-11:
@@ -7982,10 +7985,10 @@ entities:
             0: 65535
           9,-10:
             0: 32767
-            9: 32768
+            10: 32768
           9,-9:
             0: 55
-            9: 34952
+            10: 34952
           10,-11:
             0: 4369
           10,-10:
@@ -8022,13 +8025,13 @@ entities:
             0: 65535
           9,-8:
             0: 13056
-            9: 34952
+            10: 34952
           9,-7:
             0: 4403
-            9: 34952
+            10: 34952
           9,-6:
             0: 4369
-            9: 34958
+            10: 34958
           9,-5:
             0: 65535
           10,-5:
@@ -8144,12 +8147,12 @@ entities:
             0: 63283
           11,3:
             0: 65531
-            9: 4
+            10: 4
           12,0:
             0: 65535
           12,2:
             0: 4096
-            9: 17476
+            10: 17476
           12,3:
             0: 65527
           13,0:
@@ -8158,7 +8161,7 @@ entities:
             0: 12544
           12,-3:
             0: 63280
-            9: 2
+            10: 2
           12,-2:
             0: 65535
           12,-1:
@@ -8169,7 +8172,7 @@ entities:
             0: 13107
           13,-1:
             0: 30583
-            9: 128
+            10: 128
           8,4:
             0: 65535
           8,5:
@@ -8210,10 +8213,10 @@ entities:
             0: 32767
           12,6:
             0: 307
-            9: 192
+            10: 192
           13,4:
             0: 14199
-            9: 128
+            10: 128
           13,5:
             0: 19
           -6,5:
@@ -8392,10 +8395,10 @@ entities:
             0: 14199
           10,10:
             0: 4403
-            9: 32768
+            10: 32768
           10,11:
             0: 1
-            9: 142
+            10: 142
           8,12:
             0: 255
           8,13:
@@ -8504,10 +8507,10 @@ entities:
             0: 65535
           -16,-8:
             0: 65296
-            9: 1
+            10: 1
           -15,-8:
             0: 28928
-            9: 1102
+            10: 1102
           -20,-4:
             0: 65535
           -20,-3:
@@ -8548,7 +8551,7 @@ entities:
             0: 65535
           -18,-8:
             0: 51200
-            9: 1102
+            10: 1102
           -17,-8:
             0: 65504
           -20,0:
@@ -8592,47 +8595,47 @@ entities:
             0: 65535
           -12,9:
             0: 20479
-            9: 45056
+            10: 45056
           -12,10:
-            9: 11
+            10: 11
             0: 65524
           -12,11:
-            9: 11
+            10: 11
             0: 65524
           -11,8:
             0: 65535
           -11,9:
             0: 20471
-            11: 8
-            9: 45056
+            12: 8
+            10: 45056
           -11,10:
-            9: 11
+            10: 11
             0: 65524
           -11,11:
-            9: 11
+            10: 11
             0: 65524
           -10,8:
             0: 65535
           -10,9:
             0: 20477
-            11: 2
-            9: 45056
+            12: 2
+            10: 45056
           -10,10:
-            9: 11
+            10: 11
             0: 65524
           -10,11:
-            9: 11
+            10: 11
             0: 65524
           -9,8:
             0: 65535
           -9,9:
             0: 53247
-            9: 12288
+            10: 12288
           -9,10:
-            9: 3
+            10: 3
             0: 65532
           -9,11:
-            9: 3
+            10: 3
             0: 65532
           -8,8:
             0: 65535
@@ -8673,7 +8676,7 @@ entities:
             0: 65535
           -10,6:
             0: 61439
-            12: 4096
+            13: 4096
           -10,7:
             0: 65535
           -9,4:
@@ -8710,7 +8713,7 @@ entities:
             0: 65535
           -15,9:
             0: 49151
-            13: 16384
+            14: 16384
           -15,10:
             0: 65535
           -15,11:
@@ -8719,30 +8722,30 @@ entities:
             0: 65535
           -14,9:
             0: 32767
-            9: 32768
+            10: 32768
           -14,10:
             0: 65527
-            9: 8
+            10: 8
           -14,11:
             0: 65527
-            9: 8
+            10: 8
           -13,8:
             0: 65535
           -13,9:
             0: 20479
-            9: 45056
+            10: 45056
           -13,10:
-            9: 11
+            10: 11
             0: 65524
           -13,11:
-            9: 11
+            10: 11
             0: 65524
           -16,12:
             0: 206
-            9: 2048
+            10: 2048
           -15,12:
             0: 3327
-            9: 768
+            10: 768
           -14,12:
             0: 4095
           -13,12:
@@ -8777,8 +8780,8 @@ entities:
             0: 65535
           -13,6:
             0: 30591
-            8: 34816
-            14: 128
+            9: 34816
+            15: 128
           -13,7:
             0: 65535
           -20,4:
@@ -8793,24 +8796,24 @@ entities:
             0: 65535
           -19,5:
             0: 35071
-            9: 29184
+            10: 29184
           -19,6:
             0: 35064
-            9: 30214
+            10: 30214
           -19,7:
             0: 65528
-            9: 2
+            10: 2
           -18,4:
             0: 65535
           -18,5:
             0: 35071
-            9: 29184
+            10: 29184
           -18,6:
             0: 35064
-            9: 29443
+            10: 29443
           -18,7:
             0: 65528
-            9: 2
+            10: 2
           -17,4:
             0: 65535
           -17,5:
@@ -8825,10 +8828,10 @@ entities:
             0: 65535
           -22,-3:
             0: 52360
-            9: 1
+            10: 1
           -22,-4:
             0: 32768
-            9: 28928
+            10: 28928
           -21,-4:
             0: 65472
           -21,-3:
@@ -8852,38 +8855,38 @@ entities:
             0: 61439
           -21,4:
             0: 61166
-            9: 4096
+            10: 4096
           -21,5:
             0: 52428
-            9: 8738
+            10: 8738
           -21,6:
             0: 52428
-            9: 8738
+            10: 8738
           -21,7:
             0: 52428
-            9: 8738
+            10: 8738
           -20,8:
             0: 65535
           -20,9:
             0: 2255
-            9: 32800
+            10: 32800
           -19,8:
             0: 65535
           -19,9:
             0: 61439
           -19,10:
             0: 8
-            9: 16
+            10: 16
           -18,8:
             0: 65535
           -18,9:
             0: 65527
-            15: 8
+            16: 8
           -18,10:
             0: 61439
           -18,11:
             0: 12
-            9: 1826
+            10: 1826
           -17,8:
             0: 65535
           -17,9:
@@ -8894,14 +8897,14 @@ entities:
             0: 239
           -21,8:
             0: 36044
-            9: 25122
+            10: 25122
           -20,-6:
             0: 8879
           -20,-7:
             0: 41504
           -22,2:
             0: 35020
-            9: 48
+            10: 48
           -22,3:
             0: 8
           -23,-6:
@@ -8926,59 +8929,59 @@ entities:
             0: 34952
           -9,-16:
             0: 34944
-            9: 8
+            10: 8
           -9,-15:
             0: 34952
           -8,-16:
             0: 65534
-            9: 1
+            10: 1
           -8,-15:
             0: 65535
           -7,-16:
             0: 65523
-            9: 12
+            10: 12
           -7,-15:
             0: 65535
           -1,-16:
-            9: 16384
+            10: 16384
           8,-15:
-            9: 562
+            10: 562
           12,1:
-            9: 17476
+            10: 17476
           12,-4:
-            9: 9984
+            10: 9984
           14,-1:
-            9: 562
+            10: 562
           13,6:
-            9: 273
+            10: 273
           14,4:
-            9: 562
+            10: 562
           -23,2:
-            9: 2184
+            10: 2184
           -22,4:
-            9: 50176
+            10: 50176
           -22,5:
-            9: 4
+            10: 4
           -20,10:
-            9: 200
+            10: 200
           -16,-9:
-            9: 4864
+            10: 4864
           -17,-9:
-            9: 2048
+            10: 2048
           -8,12:
-            9: 1
+            10: 1
           -8,-18:
-            9: 12032
+            10: 12032
           -8,-17:
-            9: 57890
+            10: 57890
           -7,-18:
-            9: 9984
+            10: 9984
           -7,-17:
-            9: 47778
+            10: 47778
           -9,-18:
-            9: 34816
+            10: 34816
           -9,-17:
-            9: 8
+            10: 8
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -9087,6 +9090,21 @@ entities:
           - 0
         - volume: 2500
           temperature: 293.15
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14926
           moles:
           - 20.078888
           - 75.53487
@@ -10398,8 +10416,6 @@ entities:
   entities:
   - uid: 376
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-13.5
       parent: 2
@@ -10408,8 +10424,6 @@ entities:
       - 336
   - uid: 377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-10.5
       parent: 2
@@ -10418,8 +10432,6 @@ entities:
       - 335
   - uid: 378
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-10.5
       parent: 2
@@ -10428,8 +10440,6 @@ entities:
       - 415
   - uid: 379
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-13.5
       parent: 2
@@ -10438,8 +10448,6 @@ entities:
       - 399
   - uid: 14950
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-26.5
       parent: 2
@@ -10486,15 +10494,11 @@ entities:
   entities:
   - uid: 3574
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,31.5
       parent: 2
   - uid: 13063
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,31.5
       parent: 2
@@ -10502,25 +10506,16 @@ entities:
   entities:
   - uid: 1070
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-3.5
       parent: 2
   - uid: 1100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-4.5
       parent: 2
 - proto: AirlockBrigGlassLocked
   entities:
-  - uid: 144
-    components:
-    - type: Transform
-      pos: -42.5,-0.5
-      parent: 2
   - uid: 311
     components:
     - type: Transform
@@ -10532,11 +10527,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -36.5,-13.5
       parent: 2
-  - uid: 1631
-    components:
-    - type: Transform
-      pos: -42.5,1.5
-      parent: 2
   - uid: 9769
     components:
     - type: Transform
@@ -10546,8 +10536,6 @@ entities:
   entities:
   - uid: 1551
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-11.5
       parent: 2
@@ -10555,22 +10543,16 @@ entities:
   entities:
   - uid: 7358
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,25.5
       parent: 2
   - uid: 7359
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,24.5
       parent: 2
   - uid: 7395
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,27.5
       parent: 2
@@ -10578,29 +10560,21 @@ entities:
   entities:
   - uid: 9046
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,28.5
       parent: 2
   - uid: 9047
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,28.5
       parent: 2
   - uid: 9048
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,33.5
       parent: 2
   - uid: 9049
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,33.5
       parent: 2
@@ -10608,8 +10582,6 @@ entities:
   entities:
   - uid: 13162
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,44.5
       parent: 2
@@ -10617,15 +10589,11 @@ entities:
   entities:
   - uid: 233
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,5.5
       parent: 2
   - uid: 234
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,3.5
       parent: 2
@@ -10633,22 +10601,16 @@ entities:
   entities:
   - uid: 1999
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-31.5
       parent: 2
   - uid: 2002
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-31.5
       parent: 2
   - uid: 2220
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-29.5
       parent: 2
@@ -10665,7 +10627,7 @@ entities:
       pos: -54.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -4031.6829
+      secondsUntilStateChange: -5709.954
       state: Opening
   - uid: 9987
     components:
@@ -10681,8 +10643,6 @@ entities:
   entities:
   - uid: 8852
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,24.5
       parent: 2
@@ -10690,8 +10650,6 @@ entities:
   entities:
   - uid: 3023
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-43.5
       parent: 2
@@ -10868,99 +10826,71 @@ entities:
   entities:
   - uid: 58
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,31.5
       parent: 2
   - uid: 718
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,45.5
       parent: 2
   - uid: 895
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-41.5
       parent: 2
   - uid: 1196
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-49.5
       parent: 2
   - uid: 1487
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,31.5
       parent: 2
   - uid: 1797
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-23.5
       parent: 2
   - uid: 4313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-45.5
       parent: 2
   - uid: 4403
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,9.5
       parent: 2
   - uid: 5683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-0.5
       parent: 2
   - uid: 7961
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,42.5
       parent: 2
   - uid: 9837
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,17.5
       parent: 2
   - uid: 9838
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,17.5
       parent: 2
   - uid: 10275
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,25.5
       parent: 2
   - uid: 11392
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-17.5
       parent: 2
@@ -10968,29 +10898,21 @@ entities:
   entities:
   - uid: 1875
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-22.5
       parent: 2
   - uid: 2690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-49.5
       parent: 2
   - uid: 2691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-49.5
       parent: 2
   - uid: 2817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-42.5
       parent: 2
@@ -11003,8 +10925,6 @@ entities:
         - DoorStatus: DoorBolt
   - uid: 2823
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-42.5
       parent: 2
@@ -11017,8 +10937,6 @@ entities:
         - DoorStatus: DoorBolt
   - uid: 2872
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-40.5
       parent: 2
@@ -11036,8 +10954,6 @@ entities:
   entities:
   - uid: 8747
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,43.5
       parent: 2
@@ -11050,8 +10966,6 @@ entities:
         - DoorStatus: DoorBolt
   - uid: 8749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,41.5
       parent: 2
@@ -11066,8 +10980,6 @@ entities:
   entities:
   - uid: 59
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-23.5
       parent: 2
@@ -11080,8 +10992,6 @@ entities:
         - DoorStatus: DoorBolt
   - uid: 7471
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,49.5
       parent: 2
@@ -11094,8 +11004,6 @@ entities:
         - DoorStatus: DoorBolt
   - uid: 7474
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,51.5
       parent: 2
@@ -11108,8 +11016,6 @@ entities:
         - DoorStatus: DoorBolt
   - uid: 12811
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,-23.5
       parent: 2
@@ -11255,8 +11161,6 @@ entities:
   entities:
   - uid: 10728
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-1.5
       parent: 2
@@ -11269,8 +11173,6 @@ entities:
         - DoorStatus: DoorBolt
   - uid: 13345
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-1.5
       parent: 2
@@ -11285,8 +11187,6 @@ entities:
   entities:
   - uid: 935
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-21.5
       parent: 2
@@ -11391,8 +11291,6 @@ entities:
   entities:
   - uid: 518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,4.5
       parent: 2
@@ -11400,15 +11298,11 @@ entities:
   entities:
   - uid: 1488
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,-20.5
       parent: 2
   - uid: 2103
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-23.5
       parent: 2
@@ -11424,8 +11318,6 @@ entities:
   entities:
   - uid: 1026
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
@@ -11433,8 +11325,6 @@ entities:
   entities:
   - uid: 225
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
@@ -11454,8 +11344,6 @@ entities:
   entities:
   - uid: 448
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-6.5
       parent: 2
@@ -11463,8 +11351,6 @@ entities:
   entities:
   - uid: 2942
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-43.5
       parent: 2
@@ -11472,8 +11358,6 @@ entities:
   entities:
   - uid: 43
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,4.5
       parent: 2
@@ -11481,8 +11365,6 @@ entities:
   entities:
   - uid: 1988
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-28.5
       parent: 2
@@ -11490,8 +11372,6 @@ entities:
   entities:
   - uid: 1104
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-8.5
       parent: 2
@@ -11499,8 +11379,6 @@ entities:
   entities:
   - uid: 9944
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,14.5
       parent: 2
@@ -11508,8 +11386,6 @@ entities:
   entities:
   - uid: 517
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,7.5
       parent: 2
@@ -11517,8 +11393,6 @@ entities:
   entities:
   - uid: 3401
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-17.5
       parent: 2
@@ -11526,8 +11400,6 @@ entities:
   entities:
   - uid: 788
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-15.5
       parent: 2
@@ -11535,43 +11407,31 @@ entities:
   entities:
   - uid: 95
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,2.5
       parent: 2
   - uid: 384
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-6.5
       parent: 2
   - uid: 997
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-29.5
       parent: 2
   - uid: 2943
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-32.5
       parent: 2
   - uid: 3840
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,10.5
       parent: 2
   - uid: 5792
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,3.5
       parent: 2
@@ -11579,15 +11439,11 @@ entities:
   entities:
   - uid: 2210
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-18.5
       parent: 2
   - uid: 5854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-40.5
       parent: 2
@@ -11595,15 +11451,11 @@ entities:
   entities:
   - uid: 5831
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,2.5
       parent: 2
   - uid: 5832
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,1.5
       parent: 2
@@ -11611,8 +11463,6 @@ entities:
   entities:
   - uid: 9862
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,26.5
       parent: 2
@@ -11708,22 +11558,16 @@ entities:
   entities:
   - uid: 2161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-20.5
       parent: 2
   - uid: 3455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-43.5
       parent: 2
   - uid: 4350
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-21.5
       parent: 2
@@ -11750,8 +11594,6 @@ entities:
   entities:
   - uid: 9005
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,37.5
       parent: 2
@@ -11773,8 +11615,6 @@ entities:
   entities:
   - uid: 5185
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,0.5
       parent: 2
@@ -11794,8 +11634,6 @@ entities:
   entities:
   - uid: 5782
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,36.5
       parent: 2
@@ -11844,20 +11682,28 @@ entities:
   entities:
   - uid: 5409
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,6.5
       parent: 2
   - uid: 5410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,7.5
       parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -42.5,1.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -42.5,-0.5
+      parent: 2
   - uid: 426
     components:
     - type: Transform
@@ -11885,8 +11731,6 @@ entities:
   entities:
   - uid: 1489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,-24.5
       parent: 2
@@ -11894,8 +11738,6 @@ entities:
   entities:
   - uid: 9377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,-28.5
       parent: 2
@@ -11906,8 +11748,6 @@ entities:
   entities:
   - uid: 7969
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,38.5
       parent: 2
@@ -11958,15 +11798,11 @@ entities:
   entities:
   - uid: 1296
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-47.5
       parent: 2
   - uid: 12464
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-47.5
       parent: 2
@@ -12439,35 +12275,6 @@ entities:
     - type: Transform
       pos: 28.5,31.5
       parent: 2
-- proto: AmePart
-  entities:
-  - uid: 1174
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 16977
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 1175
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 16977
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 1233
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 16977
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: AnomalyCoreBluespaceInert
   entities:
   - uid: 17484
@@ -13089,6 +12896,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,27.5
       parent: 2
+- proto: ArrivalsShuttleTimer
+  entities:
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -28.5,-54.5
+      parent: 2
+  - uid: 3552
+    components:
+    - type: Transform
+      pos: -28.5,-48.5
+      parent: 2
 - proto: ArtifactFragment
   entities:
   - uid: 5446
@@ -13201,6 +13020,12 @@ entities:
     components:
     - type: Transform
       pos: -46.5,-28.5
+      parent: 2
+  - uid: 10124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -28.5,-64.5
       parent: 2
   - uid: 11008
     components:
@@ -13327,21 +13152,6 @@ entities:
     components:
     - type: Transform
       pos: -46.5,39.5
-      parent: 2
-  - uid: 13748
-    components:
-    - type: Transform
-      pos: -44.5,44.5
-      parent: 2
-  - uid: 13749
-    components:
-    - type: Transform
-      pos: -43.5,44.5
-      parent: 2
-  - uid: 13750
-    components:
-    - type: Transform
-      pos: -42.5,44.5
       parent: 2
   - uid: 13751
     components:
@@ -13999,8 +13809,6 @@ entities:
   entities:
   - uid: 13180
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -14017,6 +13825,14 @@ entities:
       parent: 2
     - type: Physics
       bodyType: Dynamic
+  - uid: 10595
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -61.5,32.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
 - proto: Beaker
   entities:
   - uid: 1034
@@ -14036,11 +13852,6 @@ entities:
       parent: 2
 - proto: Bed
   entities:
-  - uid: 390
-    components:
-    - type: Transform
-      pos: 21.5,-12.5
-      parent: 2
   - uid: 409
     components:
     - type: Transform
@@ -14350,20 +14161,10 @@ entities:
       parent: 2
 - proto: BedsheetSpawner
   entities:
-  - uid: 223
-    components:
-    - type: Transform
-      pos: 15.5,-12.5
-      parent: 2
   - uid: 382
     components:
     - type: Transform
       pos: 15.5,-9.5
-      parent: 2
-  - uid: 389
-    components:
-    - type: Transform
-      pos: 21.5,-12.5
       parent: 2
   - uid: 1124
     components:
@@ -14413,8 +14214,6 @@ entities:
   entities:
   - uid: 725
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-1.5
       parent: 2
@@ -14423,8 +14222,6 @@ entities:
       - 483
   - uid: 726
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-1.5
       parent: 2
@@ -14433,8 +14230,6 @@ entities:
       - 483
   - uid: 727
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-1.5
       parent: 2
@@ -14443,8 +14238,6 @@ entities:
       - 483
   - uid: 3465
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,43.5
       parent: 2
@@ -14453,8 +14246,6 @@ entities:
       - 12111
   - uid: 5167
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,5.5
       parent: 2
@@ -14463,8 +14254,6 @@ entities:
       - 5240
   - uid: 5296
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,8.5
       parent: 2
@@ -14473,8 +14262,6 @@ entities:
       - 5240
   - uid: 5297
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,7.5
       parent: 2
@@ -14483,8 +14270,6 @@ entities:
       - 5240
   - uid: 5298
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,6.5
       parent: 2
@@ -14493,8 +14278,6 @@ entities:
       - 5240
   - uid: 5414
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,14.5
       parent: 2
@@ -14503,8 +14286,6 @@ entities:
       - 14631
   - uid: 5415
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,13.5
       parent: 2
@@ -14513,8 +14294,6 @@ entities:
       - 14631
   - uid: 5416
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,12.5
       parent: 2
@@ -14523,8 +14302,6 @@ entities:
       - 14631
   - uid: 10767
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,28.5
       parent: 2
@@ -14533,8 +14310,6 @@ entities:
       - 7448
   - uid: 10768
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,28.5
       parent: 2
@@ -14543,8 +14318,6 @@ entities:
       - 7448
   - uid: 12391
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,43.5
       parent: 2
@@ -14617,8 +14390,6 @@ entities:
   entities:
   - uid: 4560
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4548
     - type: Physics
@@ -14647,50 +14418,36 @@ entities:
   entities:
   - uid: 164
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
   - uid: 175
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
   - uid: 186
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-2.5
       parent: 2
   - uid: 197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
   - uid: 198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
   - uid: 201
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
   - uid: 249
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,6.5
       parent: 2
@@ -14733,8 +14490,6 @@ entities:
   entities:
   - uid: 1555
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 1535
     - type: Physics
@@ -14744,8 +14499,6 @@ entities:
   entities:
   - uid: 2169
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 2168
     - type: Physics
@@ -14931,8 +14684,6 @@ entities:
   entities:
   - uid: 993
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 992
     - type: Physics
@@ -14940,8 +14691,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 1219
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 992
     - type: Physics
@@ -14961,8 +14710,6 @@ entities:
   entities:
   - uid: 1562
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 1535
     - type: Physics
@@ -14989,8 +14736,6 @@ entities:
   entities:
   - uid: 14990
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -15007,8 +14752,6 @@ entities:
   entities:
   - uid: 1561
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 1535
     - type: Physics
@@ -15033,12 +14776,12 @@ entities:
     - type: Transform
       pos: 14.5469,-54.32444
       parent: 2
-- proto: BriefcaseSyndieLobbyingBundleFilled
+- proto: BriefcaseThiefBribingBundleFilled
   entities:
-  - uid: 14106
+  - uid: 402
     components:
     - type: Transform
-      pos: -61.515984,-18.360271
+      pos: -61.48863,-18.23058
       parent: 2
 - proto: BrigTimer
   entities:
@@ -15090,8 +14833,6 @@ entities:
   entities:
   - uid: 2281
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 2278
     - type: Physics
@@ -15101,8 +14842,6 @@ entities:
   entities:
   - uid: 436
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 185
     - type: Physics
@@ -15110,8 +14849,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 437
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 185
     - type: Physics
@@ -21136,11 +20873,6 @@ entities:
     - type: Transform
       pos: -44.5,14.5
       parent: 2
-  - uid: 10294
-    components:
-    - type: Transform
-      pos: -45.5,14.5
-      parent: 2
   - uid: 10295
     components:
     - type: Transform
@@ -21680,6 +21412,11 @@ entities:
     components:
     - type: Transform
       pos: -67.5,-16.5
+      parent: 2
+  - uid: 13107
+    components:
+    - type: Transform
+      pos: -45.5,14.5
       parent: 2
   - uid: 13183
     components:
@@ -24842,30 +24579,100 @@ entities:
     - type: Transform
       pos: -8.5,14.5
       parent: 2
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -46.5,13.5
+      parent: 2
   - uid: 447
     components:
     - type: Transform
       pos: 28.5,-20.5
+      parent: 2
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -40.5,12.5
+      parent: 2
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -41.5,11.5
       parent: 2
   - uid: 620
     components:
     - type: Transform
       pos: 28.5,-19.5
       parent: 2
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: -45.5,11.5
+      parent: 2
   - uid: 1051
     components:
     - type: Transform
       pos: 33.5,-49.5
+      parent: 2
+  - uid: 1059
+    components:
+    - type: Transform
+      pos: -43.5,15.5
+      parent: 2
+  - uid: 1099
+    components:
+    - type: Transform
+      pos: -46.5,15.5
+      parent: 2
+  - uid: 1103
+    components:
+    - type: Transform
+      pos: -42.5,11.5
+      parent: 2
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: -40.5,11.5
+      parent: 2
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: -40.5,13.5
+      parent: 2
+  - uid: 1174
+    components:
+    - type: Transform
+      pos: -40.5,15.5
+      parent: 2
+  - uid: 1175
+    components:
+    - type: Transform
+      pos: -41.5,15.5
+      parent: 2
+  - uid: 1233
+    components:
+    - type: Transform
+      pos: -43.5,11.5
       parent: 2
   - uid: 1588
     components:
     - type: Transform
       pos: -27.5,-39.5
       parent: 2
+  - uid: 1631
+    components:
+    - type: Transform
+      pos: -40.5,14.5
+      parent: 2
   - uid: 2371
     components:
     - type: Transform
       pos: -8.5,7.5
+      parent: 2
+  - uid: 2414
+    components:
+    - type: Transform
+      pos: -44.5,11.5
       parent: 2
   - uid: 2419
     components:
@@ -24902,6 +24709,11 @@ entities:
     - type: Transform
       pos: -2.5,-43.5
       parent: 2
+  - uid: 2743
+    components:
+    - type: Transform
+      pos: -46.5,11.5
+      parent: 2
   - uid: 2772
     components:
     - type: Transform
@@ -24922,10 +24734,30 @@ entities:
     - type: Transform
       pos: 43.5,-49.5
       parent: 2
+  - uid: 3148
+    components:
+    - type: Transform
+      pos: -46.5,14.5
+      parent: 2
   - uid: 3181
     components:
     - type: Transform
       pos: 44.5,-1.5
+      parent: 2
+  - uid: 3252
+    components:
+    - type: Transform
+      pos: -46.5,12.5
+      parent: 2
+  - uid: 3256
+    components:
+    - type: Transform
+      pos: -45.5,15.5
+      parent: 2
+  - uid: 3259
+    components:
+    - type: Transform
+      pos: -44.5,15.5
       parent: 2
   - uid: 3821
     components:
@@ -27032,46 +26864,6 @@ entities:
     - type: Transform
       pos: -41.5,16.5
       parent: 2
-  - uid: 10107
-    components:
-    - type: Transform
-      pos: -41.5,15.5
-      parent: 2
-  - uid: 10108
-    components:
-    - type: Transform
-      pos: -41.5,14.5
-      parent: 2
-  - uid: 10109
-    components:
-    - type: Transform
-      pos: -41.5,13.5
-      parent: 2
-  - uid: 10110
-    components:
-    - type: Transform
-      pos: -42.5,13.5
-      parent: 2
-  - uid: 10111
-    components:
-    - type: Transform
-      pos: -43.5,13.5
-      parent: 2
-  - uid: 10112
-    components:
-    - type: Transform
-      pos: -44.5,13.5
-      parent: 2
-  - uid: 10113
-    components:
-    - type: Transform
-      pos: -45.5,13.5
-      parent: 2
-  - uid: 10114
-    components:
-    - type: Transform
-      pos: -41.5,12.5
-      parent: 2
   - uid: 10130
     components:
     - type: Transform
@@ -27146,11 +26938,6 @@ entities:
     components:
     - type: Transform
       pos: -42.5,15.5
-      parent: 2
-  - uid: 10175
-    components:
-    - type: Transform
-      pos: -42.5,14.5
       parent: 2
   - uid: 10177
     components:
@@ -28724,11 +28511,6 @@ entities:
       parent: 2
 - proto: CableHVStack
   entities:
-  - uid: 3274
-    components:
-    - type: Transform
-      pos: -40.501667,33.46546
-      parent: 2
   - uid: 4270
     components:
     - type: Transform
@@ -28744,6 +28526,11 @@ entities:
     components:
     - type: Transform
       pos: 18.485188,49.748962
+      parent: 2
+  - uid: 10114
+    components:
+    - type: Transform
+      pos: -42.558983,34.532436
       parent: 2
   - uid: 14114
     components:
@@ -34123,8 +33910,6 @@ entities:
   entities:
   - uid: 1665
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3565
     - type: Physics
@@ -36538,96 +36323,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,19.5
-      parent: 2
-  - uid: 10115
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -45.5,14.5
-      parent: 2
-  - uid: 10116
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -45.5,13.5
-      parent: 2
-  - uid: 10117
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -45.5,12.5
-      parent: 2
-  - uid: 10118
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -44.5,14.5
-      parent: 2
-  - uid: 10119
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -44.5,13.5
-      parent: 2
-  - uid: 10120
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -44.5,12.5
-      parent: 2
-  - uid: 10121
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -43.5,14.5
-      parent: 2
-  - uid: 10122
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -43.5,13.5
-      parent: 2
-  - uid: 10123
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -43.5,12.5
-      parent: 2
-  - uid: 10124
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -42.5,14.5
-      parent: 2
-  - uid: 10125
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -42.5,13.5
-      parent: 2
-  - uid: 10126
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -42.5,12.5
-      parent: 2
-  - uid: 10127
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,14.5
-      parent: 2
-  - uid: 10128
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,13.5
-      parent: 2
-  - uid: 10129
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,12.5
       parent: 2
   - uid: 10132
     components:
@@ -39251,7 +38946,6 @@ entities:
           ents:
           - 437
           - 436
-          - 435
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -39511,12 +39205,12 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 3567
+          - 3569
+          - 3568
+          - 1546
           - 3566
           - 1665
-          - 1546
-          - 3568
-          - 3569
-          - 3567
 - proto: ClothingBackpackDuffelSalvage
   entities:
   - uid: 2644
@@ -39535,8 +39229,6 @@ entities:
   entities:
   - uid: 15001
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39546,8 +39238,6 @@ entities:
   entities:
   - uid: 14997
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39576,8 +39266,6 @@ entities:
   entities:
   - uid: 4559
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4548
     - type: Physics
@@ -39587,8 +39275,6 @@ entities:
   entities:
   - uid: 14996
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39612,8 +39298,6 @@ entities:
   entities:
   - uid: 13668
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13666
     - type: Physics
@@ -39621,8 +39305,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13669
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13666
     - type: Physics
@@ -39630,8 +39312,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13670
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13666
     - type: Physics
@@ -39665,8 +39345,6 @@ entities:
   entities:
   - uid: 2279
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 2278
     - type: Physics
@@ -39676,8 +39354,6 @@ entities:
   entities:
   - uid: 2460
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 406
     - type: Physics
@@ -39685,8 +39361,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 3464
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3226
     - type: Physics
@@ -39699,8 +39373,6 @@ entities:
       parent: 2
   - uid: 12160
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12157
     - type: Physics
@@ -39708,8 +39380,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 12167
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12163
     - type: Physics
@@ -39741,8 +39411,6 @@ entities:
   entities:
   - uid: 14991
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39759,8 +39427,6 @@ entities:
   entities:
   - uid: 14992
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39777,8 +39443,6 @@ entities:
   entities:
   - uid: 14998
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39788,8 +39452,6 @@ entities:
   entities:
   - uid: 14999
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39839,8 +39501,6 @@ entities:
   entities:
   - uid: 3071
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3070
     - type: Physics
@@ -39848,8 +39508,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 12959
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12936
     - type: Physics
@@ -39922,8 +39580,6 @@ entities:
   entities:
   - uid: 14993
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -39933,8 +39589,6 @@ entities:
   entities:
   - uid: 903
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -39942,8 +39596,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 904
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -39951,8 +39603,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 906
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -39960,8 +39610,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 986
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -40002,8 +39650,6 @@ entities:
   entities:
   - uid: 13223
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -40090,8 +39736,6 @@ entities:
   entities:
   - uid: 3073
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3070
     - type: Physics
@@ -40137,8 +39781,6 @@ entities:
   entities:
   - uid: 907
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -40146,8 +39788,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 985
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -40157,8 +39797,6 @@ entities:
   entities:
   - uid: 905
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -40166,8 +39804,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 910
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -40177,8 +39813,6 @@ entities:
   entities:
   - uid: 13667
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13666
     - type: Physics
@@ -40195,8 +39829,6 @@ entities:
   entities:
   - uid: 7376
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7374
     - type: Physics
@@ -40206,8 +39838,6 @@ entities:
   entities:
   - uid: 9087
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 9085
     - type: Physics
@@ -40217,8 +39847,6 @@ entities:
   entities:
   - uid: 7156
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12924
     - type: Physics
@@ -40228,8 +39856,6 @@ entities:
   entities:
   - uid: 10720
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7111
     - type: Physics
@@ -40237,8 +39863,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 12916
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7111
     - type: Physics
@@ -40246,8 +39870,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13148
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13147
     - type: Physics
@@ -40255,8 +39877,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13149
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13147
     - type: Physics
@@ -40264,8 +39884,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 16752
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 16751
     - type: Physics
@@ -40273,8 +39891,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 16753
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 16751
     - type: Physics
@@ -40319,8 +39935,6 @@ entities:
   entities:
   - uid: 14995
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -40330,8 +39944,6 @@ entities:
   entities:
   - uid: 3229
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3189
     - type: Physics
@@ -40354,8 +39966,6 @@ entities:
   entities:
   - uid: 3339
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3226
     - type: Physics
@@ -40363,8 +39973,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 3569
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3565
     - type: Physics
@@ -40372,8 +39980,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 12158
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12157
     - type: Physics
@@ -40381,8 +39987,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 12164
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12163
     - type: Physics
@@ -40392,8 +39996,6 @@ entities:
   entities:
   - uid: 14994
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -40422,8 +40024,6 @@ entities:
   entities:
   - uid: 13134
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7111
     - type: Physics
@@ -40431,8 +40031,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13144
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7111
     - type: Physics
@@ -40440,8 +40038,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13150
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13147
     - type: Physics
@@ -40449,8 +40045,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13241
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13147
     - type: Physics
@@ -40458,8 +40052,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 16755
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 16751
     - type: Physics
@@ -40467,8 +40059,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 16758
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 16751
     - type: Physics
@@ -40513,8 +40103,6 @@ entities:
   entities:
   - uid: 15000
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 14989
     - type: Physics
@@ -40524,8 +40112,6 @@ entities:
   entities:
   - uid: 12968
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12936
     - type: Physics
@@ -40535,8 +40121,6 @@ entities:
   entities:
   - uid: 13177
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -40694,6 +40278,12 @@ entities:
       parent: 2
 - proto: CockroachTimedSpawner
   entities:
+  - uid: 10125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -52.5,27.5
+      parent: 2
   - uid: 15111
     components:
     - type: Transform
@@ -41399,11 +40989,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 993
-          - 994
-          - 995
-          - 1219
           - 1684
+          - 1219
+          - 995
+          - 994
+          - 993
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -41444,99 +41034,6 @@ entities:
           showEnts: False
           occludes: True
           ent: null
-- proto: CrateEngineeringAMEControl
-  entities:
-  - uid: 17045
-    components:
-    - type: Transform
-      pos: -46.5,12.5
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-- proto: CrateEngineeringAMEJar
-  entities:
-  - uid: 11073
-    components:
-    - type: Transform
-      pos: -63.5,29.5
-      parent: 2
-  - uid: 16980
-    components:
-    - type: Transform
-      pos: -46.5,13.5
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-- proto: CrateEngineeringAMEShielding
-  entities:
-  - uid: 16977
-    components:
-    - type: Transform
-      pos: -46.5,14.5
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 1233
-          - 1175
-          - 1174
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: CrateEngineeringCableBulk
   entities:
   - uid: 4312
@@ -41548,6 +41045,11 @@ entities:
     components:
     - type: Transform
       pos: -27.5,25.5
+      parent: 2
+  - uid: 10175
+    components:
+    - type: Transform
+      pos: -60.5,32.5
       parent: 2
   - uid: 13277
     components:
@@ -41579,6 +41081,13 @@ entities:
         - 0
         - 0
         - 0
+- proto: CrateEngineeringMiniJetpack
+  entities:
+  - uid: 12316
+    components:
+    - type: Transform
+      pos: -61.5,29.5
+      parent: 2
 - proto: CrateEngineeringSecure
   entities:
   - uid: 12924
@@ -41612,6 +41121,43 @@ entities:
           ents:
           - 7156
           - 7165
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 13108
+    components:
+    - type: Transform
+      pos: -44.5,13.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14627
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 13109
+          - 13110
+          - 13111
+          - 13112
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -41749,9 +41295,9 @@ entities:
     - type: Transform
       pos: -59.5,30.5
       parent: 2
-- proto: CrateMaterialPlastic
+- proto: CrateMaterialPlasteel
   entities:
-  - uid: 11085
+  - uid: 3555
     components:
     - type: Transform
       pos: -59.5,32.5
@@ -42118,8 +41664,6 @@ entities:
       parent: 2
   - uid: 2458
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 237
     - type: Physics
@@ -42184,27 +41728,13 @@ entities:
       parent: 2
 - proto: CryogenicSleepUnit
   entities:
-  - uid: 3148
+  - uid: 3562
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: 8.5,-52.5
       parent: 2
-  - uid: 3252
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-48.5
-      parent: 2
-- proto: CryogenicSleepUnitSpawner
-  entities:
-  - uid: 3256
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-50.5
-      parent: 2
-  - uid: 3562
+  - uid: 3563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -42214,48 +41744,58 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-51.5
+      pos: 5.5,-49.5
       parent: 2
   - uid: 3576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: 6.5,-48.5
+      parent: 2
+  - uid: 3842
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-51.5
+      parent: 2
+  - uid: 3947
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 6.5,-52.5
       parent: 2
-  - uid: 10026
-    components:
-    - type: Transform
-      pos: 21.5,-9.5
-      parent: 2
-- proto: CryogenicSleepUnitSpawnerLateJoin
-  entities:
-  - uid: 3504
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-49.5
-      parent: 2
-  - uid: 3552
+  - uid: 4363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-48.5
       parent: 2
-  - uid: 3555
+  - uid: 6676
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: 7.5,-52.5
       parent: 2
-  - uid: 11943
+- proto: CryogenicSleepUnitSpawner
+  entities:
+  - uid: 10026
     components:
     - type: Transform
-      pos: 9.5,-49.5
+      pos: 21.5,-9.5
       parent: 2
-  - uid: 11969
+  - uid: 11073
     components:
     - type: Transform
-      pos: 9.5,-51.5
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-12.5
+      parent: 2
+- proto: CryogenicSleepUnitSpawnerLateJoin
+  entities:
+  - uid: 390
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-12.5
       parent: 2
 - proto: CryoPod
   entities:
@@ -42717,6 +42257,12 @@ entities:
     - type: Transform
       pos: -68.5,-1.5
       parent: 2
+  - uid: 13106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -72.5,-2.5
+      parent: 2
   - uid: 13237
     components:
     - type: Transform
@@ -42929,8 +42475,6 @@ entities:
   entities:
   - uid: 13222
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -43328,15 +42872,6 @@ entities:
       parent: 2
     - type: WarpPoint
       location: Командование - Хранилище
-- proto: DefaultStationBeaconTeslaEngine
-  entities:
-  - uid: 14697
-    components:
-    - type: Transform
-      pos: -61.5,25.5
-      parent: 2
-    - type: WarpPoint
-      location: Инженерия - Генератор Теслы
 - proto: DefaultStationBeaconWardensOffice
   entities:
   - uid: 13772
@@ -47321,6 +46856,11 @@ entities:
     - type: Transform
       pos: -23.5,36.5
       parent: 2
+  - uid: 11064
+    components:
+    - type: Transform
+      pos: -39.5,27.5
+      parent: 2
 - proto: DonkpocketBoxSpawner
   entities:
   - uid: 723
@@ -47354,8 +46894,6 @@ entities:
   entities:
   - uid: 9086
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 9085
     - type: Physics
@@ -47523,13 +47061,6 @@ entities:
     - type: Transform
       pos: 10.458143,31.988188
       parent: 2
-- proto: DrinkIceCreamGlass
-  entities:
-  - uid: 12591
-    components:
-    - type: Transform
-      pos: -32.779964,45.628044
-      parent: 2
 - proto: DrinkMopwataBottleRandom
   entities:
   - uid: 4417
@@ -47594,13 +47125,6 @@ entities:
     components:
     - type: Transform
       pos: -28.695759,-6.42085
-      parent: 2
-- proto: DrinkTeapot
-  entities:
-  - uid: 540
-    components:
-    - type: Transform
-      pos: -13.560051,0.68233776
       parent: 2
 - proto: DrinkVermouthBottleFull
   entities:
@@ -48245,8 +47769,6 @@ entities:
   entities:
   - uid: 7346
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7345
     - type: Physics
@@ -48255,8 +47777,6 @@ entities:
   entities:
   - uid: 7344
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7343
     - type: Physics
@@ -48265,8 +47785,6 @@ entities:
   entities:
   - uid: 7342
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7341
     - type: Physics
@@ -48275,8 +47793,6 @@ entities:
   entities:
   - uid: 7350
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7349
     - type: Physics
@@ -48285,8 +47801,6 @@ entities:
   entities:
   - uid: 7336
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7335
     - type: Physics
@@ -48295,8 +47809,6 @@ entities:
   entities:
   - uid: 7348
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7347
     - type: Physics
@@ -48305,8 +47817,6 @@ entities:
   entities:
   - uid: 7338
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7337
     - type: Physics
@@ -48315,8 +47825,6 @@ entities:
   entities:
   - uid: 7340
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7339
     - type: Physics
@@ -48326,7 +47834,7 @@ entities:
   - uid: 2034
     components:
     - type: Transform
-      pos: 6.357058,-30.119429
+      pos: 6.3170567,-30.435608
       parent: 2
 - proto: ExosuitFabricator
   entities:
@@ -48757,18 +48265,6 @@ entities:
       prototypes:
       - MobCatCake
       - MobBreadDog
-  - uid: 13227
-    components:
-    - type: MetaData
-      name: злой двойник или скелет
-    - type: Transform
-      pos: 8.5,-52.5
-      parent: 2
-    - type: RandomSpawner
-      chance: 0.2
-      prototypes:
-      - SpawnPointEvilTwin
-      - MobSkeletonCloset
   - uid: 17107
     components:
     - type: Transform
@@ -52871,8 +52367,6 @@ entities:
   entities:
   - uid: 3072
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3070
     - type: Physics
@@ -52918,31 +52412,25 @@ entities:
   entities:
   - uid: 994
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 992
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: FoodBoxDonkpocketGondola
+- proto: FoodBoxDonkpocketPizza
   entities:
+  - uid: 995
+    components:
+    - type: Transform
+      parent: 992
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 9332
     components:
     - type: Transform
       pos: -46.515743,3.8969553
       parent: 2
-- proto: FoodBoxDonkpocketPizza
-  entities:
-  - uid: 995
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 992
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: FoodBoxDonkpocketSpicy
   entities:
   - uid: 5184
@@ -53058,8 +52546,6 @@ entities:
   entities:
   - uid: 7377
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7374
     - type: Physics
@@ -53069,8 +52555,6 @@ entities:
   entities:
   - uid: 7375
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7374
     - type: Physics
@@ -53211,8 +52695,6 @@ entities:
   entities:
   - uid: 1684
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 992
     - type: Physics
@@ -53255,6 +52737,15 @@ entities:
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
+- proto: GasMinerCarbonDioxide
+  entities:
+  - uid: 13071
+    components:
+    - type: Transform
+      pos: -39.5,44.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
 - proto: GasMinerNitrogenStationLarge
   entities:
   - uid: 13258
@@ -53270,6 +52761,15 @@ entities:
     components:
     - type: Transform
       pos: -47.5,40.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+- proto: GasMinerWaterVapor
+  entities:
+  - uid: 13060
+    components:
+    - type: Transform
+      pos: -35.5,44.5
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
@@ -53291,10 +52791,17 @@ entities:
       color: '#17E8E2FF'
 - proto: GasOutletInjector
   entities:
-  - uid: 10355
+  - uid: 10108
     components:
     - type: Transform
-      pos: -44.5,44.5
+      pos: -38.5,44.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
+  - uid: 10117
+    components:
+    - type: Transform
+      pos: -36.5,44.5
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
@@ -53309,20 +52816,6 @@ entities:
     components:
     - type: Transform
       pos: -52.5,44.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 13133
-    components:
-    - type: Transform
-      pos: -40.5,44.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 16985
-    components:
-    - type: Transform
-      pos: -36.5,44.5
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
@@ -53353,6 +52846,13 @@ entities:
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
+  - uid: 10120
+    components:
+    - type: Transform
+      pos: -40.5,44.5
+      parent: 2
+    - type: AtmosDevice
+      joinedGrid: 2
   - uid: 10456
     components:
     - type: Transform
@@ -53360,21 +52860,7 @@ entities:
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
-  - uid: 10459
-    components:
-    - type: Transform
-      pos: -42.5,44.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
   - uid: 10460
-    components:
-    - type: Transform
-      pos: -38.5,44.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 10461
     components:
     - type: Transform
       pos: -34.5,44.5
@@ -54358,6 +53844,11 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#17E8E2FF'
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: -40.5,42.5
+      parent: 2
   - uid: 1225
     components:
     - type: Transform
@@ -54857,6 +54348,11 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
+  - uid: 7626
+    components:
+    - type: Transform
+      pos: -34.5,42.5
+      parent: 2
   - uid: 7920
     components:
     - type: Transform
@@ -54897,6 +54393,26 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0000FFFF'
+  - uid: 10111
+    components:
+    - type: Transform
+      pos: -40.5,43.5
+      parent: 2
+  - uid: 10118
+    components:
+    - type: Transform
+      pos: -34.5,43.5
+      parent: 2
+  - uid: 10121
+    components:
+    - type: Transform
+      pos: -38.5,43.5
+      parent: 2
+  - uid: 10129
+    components:
+    - type: Transform
+      pos: -36.5,43.5
+      parent: 2
   - uid: 10169
     components:
     - type: Transform
@@ -54910,6 +54426,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,38.5
+      parent: 2
+  - uid: 10459
+    components:
+    - type: Transform
+      pos: -38.5,42.5
       parent: 2
   - uid: 10527
     components:
@@ -55036,6 +54557,11 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
+  - uid: 12591
+    components:
+    - type: Transform
+      pos: -36.5,42.5
+      parent: 2
   - uid: 12614
     components:
     - type: Transform
@@ -55113,31 +54639,6 @@ entities:
     components:
     - type: Transform
       pos: -46.5,43.5
-      parent: 2
-  - uid: 13138
-    components:
-    - type: Transform
-      pos: -44.5,43.5
-      parent: 2
-  - uid: 13140
-    components:
-    - type: Transform
-      pos: -42.5,43.5
-      parent: 2
-  - uid: 13141
-    components:
-    - type: Transform
-      pos: -40.5,43.5
-      parent: 2
-  - uid: 13143
-    components:
-    - type: Transform
-      pos: -38.5,43.5
-      parent: 2
-  - uid: 13146
-    components:
-    - type: Transform
-      pos: -34.5,43.5
       parent: 2
   - uid: 13168
     components:
@@ -64312,11 +63813,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0000FFFF'
-  - uid: 16964
-    components:
-    - type: Transform
-      pos: -36.5,43.5
-      parent: 2
   - uid: 17015
     components:
     - type: Transform
@@ -65136,51 +64632,6 @@ entities:
       color: '#FF0000FF'
 - proto: GasPressurePump
   entities:
-  - uid: 1059
-    components:
-    - type: Transform
-      pos: -34.5,42.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 1099
-    components:
-    - type: Transform
-      pos: -38.5,42.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 1103
-    components:
-    - type: Transform
-      pos: -42.5,42.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 1111
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -36.5,42.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 1112
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -40.5,42.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 1120
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -44.5,42.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
   - uid: 2433
     components:
     - type: Transform
@@ -65295,8 +64746,6 @@ entities:
   entities:
   - uid: 3568
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3565
     - type: Physics
@@ -68775,6 +68224,16 @@ entities:
     - type: Transform
       pos: -55.5,46.5
       parent: 2
+  - uid: 9497
+    components:
+    - type: Transform
+      pos: -39.5,43.5
+      parent: 2
+  - uid: 9498
+    components:
+    - type: Transform
+      pos: -35.5,43.5
+      parent: 2
   - uid: 9510
     components:
     - type: Transform
@@ -68829,6 +68288,26 @@ entities:
     components:
     - type: Transform
       pos: -41.5,28.5
+      parent: 2
+  - uid: 10110
+    components:
+    - type: Transform
+      pos: -40.5,43.5
+      parent: 2
+  - uid: 10112
+    components:
+    - type: Transform
+      pos: -38.5,43.5
+      parent: 2
+  - uid: 10122
+    components:
+    - type: Transform
+      pos: -36.5,43.5
+      parent: 2
+  - uid: 10356
+    components:
+    - type: Transform
+      pos: -34.5,43.5
       parent: 2
   - uid: 10358
     components:
@@ -69170,51 +68649,6 @@ entities:
     - type: Transform
       pos: -46.5,43.5
       parent: 2
-  - uid: 13105
-    components:
-    - type: Transform
-      pos: -44.5,43.5
-      parent: 2
-  - uid: 13106
-    components:
-    - type: Transform
-      pos: -43.5,43.5
-      parent: 2
-  - uid: 13107
-    components:
-    - type: Transform
-      pos: -42.5,43.5
-      parent: 2
-  - uid: 13108
-    components:
-    - type: Transform
-      pos: -40.5,43.5
-      parent: 2
-  - uid: 13109
-    components:
-    - type: Transform
-      pos: -39.5,43.5
-      parent: 2
-  - uid: 13110
-    components:
-    - type: Transform
-      pos: -38.5,43.5
-      parent: 2
-  - uid: 13111
-    components:
-    - type: Transform
-      pos: -36.5,43.5
-      parent: 2
-  - uid: 13112
-    components:
-    - type: Transform
-      pos: -35.5,43.5
-      parent: 2
-  - uid: 13113
-    components:
-    - type: Transform
-      pos: -34.5,43.5
-      parent: 2
   - uid: 13195
     components:
     - type: Transform
@@ -69497,14 +68931,16 @@ entities:
       parent: 2
 - proto: GrilleDiagonal
   entities:
-  - uid: 1007
+  - uid: 10520
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -32.5,-63.5
       parent: 2
-  - uid: 10595
+  - uid: 12349
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -24.5,-63.5
       parent: 2
   - uid: 17472
@@ -69991,13 +69427,6 @@ entities:
     - type: Transform
       pos: -0.44786274,2.4817672
       parent: 14719
-- proto: HandheldCrewMonitor
-  entities:
-  - uid: 4363
-    components:
-    - type: Transform
-      pos: 5.660223,-20.46654
-      parent: 2
 - proto: HandheldHealthAnalyzer
   entities:
   - uid: 3217
@@ -70042,15 +69471,11 @@ entities:
   entities:
   - uid: 1294
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-16.5
       parent: 2
   - uid: 1479
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-17.5
       parent: 2
@@ -70058,8 +69483,6 @@ entities:
   entities:
   - uid: 7266
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,30.5
       parent: 2
@@ -70091,57 +69514,36 @@ entities:
   entities:
   - uid: 4469
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-24.5
       parent: 2
   - uid: 4471
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-23.5
       parent: 2
   - uid: 4472
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-22.5
       parent: 2
   - uid: 9177
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-12.5
       parent: 2
   - uid: 13157
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-13.5
       parent: 2
   - uid: 15496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-9.5
       parent: 2
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 402
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-12.5
-      parent: 2
-    - type: Door
-      secondsUntilStateChange: -89330.64
-      state: Closing
   - uid: 1457
     components:
     - type: Transform
@@ -70392,8 +69794,6 @@ entities:
       parent: 2
   - uid: 13218
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -70401,8 +69801,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13219
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -70410,8 +69808,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13221
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -70572,8 +69968,6 @@ entities:
   entities:
   - uid: 3567
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3565
     - type: Physics
@@ -70583,8 +69977,6 @@ entities:
   entities:
   - uid: 2352
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3226
     - type: Physics
@@ -70592,8 +69984,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 2374
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12157
     - type: Physics
@@ -70601,8 +69991,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 2917
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12163
     - type: Physics
@@ -71543,6 +70931,20 @@ entities:
     - type: Transform
       pos: 37.5,7.5
       parent: 2
+- proto: MachineCentrifuge
+  entities:
+  - uid: 10355
+    components:
+    - type: Transform
+      pos: 6.5,-30.5
+      parent: 2
+- proto: MachineElectrolysisUnit
+  entities:
+  - uid: 10113
+    components:
+    - type: Transform
+      pos: 2.5,-27.5
+      parent: 2
 - proto: MachineFrame
   entities:
   - uid: 5876
@@ -71885,8 +71287,6 @@ entities:
   entities:
   - uid: 7165
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12924
     - type: Physics
@@ -72022,6 +71422,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 17.5,-19.5
       parent: 2
+- proto: MothroachCube
+  entities:
+  - uid: 6896
+    components:
+    - type: Transform
+      pos: -32.734325,45.41456
+      parent: 2
 - proto: MouseTimedSpawner
   entities:
   - uid: 16997
@@ -72033,11 +71440,6 @@ entities:
     components:
     - type: Transform
       pos: -8.5,33.5
-      parent: 2
-  - uid: 16999
-    components:
-    - type: Transform
-      pos: -52.5,27.5
       parent: 2
   - uid: 17000
     components:
@@ -72155,8 +71557,6 @@ entities:
   entities:
   - uid: 2280
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 2278
     - type: Physics
@@ -72197,8 +71597,6 @@ entities:
   entities:
   - uid: 3716
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3715
     - type: Physics
@@ -72585,8 +71983,6 @@ entities:
   entities:
   - uid: 4549
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4548
     - type: ContainerContainer
@@ -72611,82 +72007,64 @@ entities:
   entities:
   - uid: 4550
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4551
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4552
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4553
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4554
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4555
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4556
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4557
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
   - uid: 4558
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 4549
     - type: Physics
       canCollide: False
 - proto: PlasmaCanister
   entities:
-  - uid: 3842
+  - uid: 10738
     components:
     - type: Transform
-      pos: -51.5,33.5
+      pos: -59.5,40.5
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
@@ -72835,10 +72213,10 @@ entities:
       parent: 2
 - proto: PlushieLizard
   entities:
-  - uid: 14573
+  - uid: 10127
     components:
     - type: Transform
-      pos: -32.325665,45.64367
+      pos: -32.359325,45.586433
       parent: 2
 - proto: PlushieLizardMirrored
   entities:
@@ -72915,15 +72293,42 @@ entities:
       parent: 2
 - proto: PortableGeneratorPacman
   entities:
+  - uid: 435
+    components:
+    - type: Transform
+      anchored: True
+      pos: -46.5,11.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
+  - uid: 2398
+    components:
+    - type: Transform
+      anchored: True
+      pos: -40.5,11.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
+  - uid: 3081
+    components:
+    - type: Transform
+      anchored: True
+      pos: -40.5,15.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
+  - uid: 3274
+    components:
+    - type: Transform
+      anchored: True
+      pos: -46.5,15.5
+      parent: 2
+    - type: Physics
+      bodyType: Static
   - uid: 7999
     components:
     - type: Transform
       pos: 15.5,39.5
-      parent: 2
-  - uid: 16981
-    components:
-    - type: Transform
-      pos: -60.5,32.5
       parent: 2
 - proto: PortableGeneratorSuperPacman
   entities:
@@ -73285,8 +72690,6 @@ entities:
   entities:
   - uid: 12054
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12046
     - type: Physics
@@ -73343,1595 +72746,1178 @@ entities:
   entities:
   - uid: 142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 2
   - uid: 146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 2
   - uid: 349
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,1.5
       parent: 2
   - uid: 351
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 2
   - uid: 395
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-6.5
       parent: 2
   - uid: 397
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-9.5
       parent: 2
   - uid: 410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-11.5
       parent: 2
   - uid: 417
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-5.5
       parent: 2
   - uid: 424
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-1.5
       parent: 2
   - uid: 704
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-0.5
       parent: 2
   - uid: 705
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-0.5
       parent: 2
   - uid: 706
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,3.5
       parent: 2
   - uid: 707
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,3.5
       parent: 2
   - uid: 710
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 2
   - uid: 713
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,3.5
       parent: 2
   - uid: 716
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,6.5
       parent: 2
   - uid: 828
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-21.5
       parent: 2
   - uid: 834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-2.5
       parent: 2
   - uid: 835
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-2.5
       parent: 2
   - uid: 900
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 2
   - uid: 908
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-22.5
       parent: 2
   - uid: 1033
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-19.5
       parent: 2
   - uid: 1035
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-25.5
       parent: 2
   - uid: 1088
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-19.5
       parent: 2
   - uid: 1125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 2
   - uid: 1126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-9.5
       parent: 2
   - uid: 1129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,-7.5
       parent: 2
   - uid: 1230
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-15.5
       parent: 2
   - uid: 1819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-15.5
       parent: 2
   - uid: 1821
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -51.5,-19.5
       parent: 2
   - uid: 1854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-25.5
       parent: 2
   - uid: 1886
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,7.5
       parent: 2
   - uid: 1896
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,4.5
       parent: 2
   - uid: 1927
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-13.5
       parent: 2
   - uid: 2041
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-26.5
       parent: 2
   - uid: 2060
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-30.5
       parent: 2
   - uid: 2069
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-26.5
       parent: 2
   - uid: 2225
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-38.5
       parent: 2
   - uid: 2228
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-38.5
       parent: 2
   - uid: 2233
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-40.5
       parent: 2
   - uid: 2234
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-40.5
       parent: 2
   - uid: 2292
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-28.5
       parent: 2
   - uid: 2357
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,5.5
       parent: 2
   - uid: 2423
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,-38.5
       parent: 2
   - uid: 2471
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-26.5
       parent: 2
   - uid: 2477
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-50.5
       parent: 2
   - uid: 2534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-32.5
       parent: 2
   - uid: 2536
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-40.5
       parent: 2
   - uid: 2537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-40.5
       parent: 2
   - uid: 2584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,-10.5
       parent: 2
   - uid: 2834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-50.5
       parent: 2
   - uid: 2835
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-50.5
       parent: 2
   - uid: 2999
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-55.5
       parent: 2
   - uid: 3056
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,11.5
       parent: 2
   - uid: 3067
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-54.5
       parent: 2
   - uid: 3074
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-54.5
       parent: 2
   - uid: 3099
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-55.5
       parent: 2
   - uid: 3101
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-44.5
       parent: 2
   - uid: 3144
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-44.5
       parent: 2
   - uid: 3173
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,11.5
       parent: 2
   - uid: 3174
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,16.5
       parent: 2
   - uid: 3175
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,16.5
       parent: 2
   - uid: 3177
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,15.5
       parent: 2
   - uid: 3314
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,29.5
       parent: 2
   - uid: 3380
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,32.5
       parent: 2
   - uid: 3388
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,32.5
       parent: 2
   - uid: 3409
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-44.5
       parent: 2
   - uid: 4007
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-44.5
       parent: 2
   - uid: 4032
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-44.5
       parent: 2
   - uid: 4033
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-39.5
       parent: 2
   - uid: 4046
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,5.5
       parent: 2
   - uid: 4051
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,0.5
       parent: 2
   - uid: 4055
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,0.5
       parent: 2
   - uid: 4374
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-37.5
       parent: 2
   - uid: 4375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-37.5
       parent: 2
   - uid: 4511
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-18.5
       parent: 2
   - uid: 4512
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-20.5
       parent: 2
   - uid: 5152
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,-8.5
       parent: 2
   - uid: 5154
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,-1.5
       parent: 2
   - uid: 5155
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,-1.5
       parent: 2
   - uid: 5189
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 43.5,9.5
       parent: 2
   - uid: 5364
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,18.5
       parent: 2
   - uid: 5365
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,18.5
       parent: 2
   - uid: 5440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-0.5
       parent: 2
   - uid: 5441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-4.5
       parent: 2
   - uid: 5442
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-2.5
       parent: 2
   - uid: 5530
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,14.5
       parent: 2
   - uid: 5531
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,14.5
       parent: 2
   - uid: 5568
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,11.5
       parent: 2
   - uid: 5647
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,0.5
       parent: 2
   - uid: 5649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,4.5
       parent: 2
   - uid: 5650
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,4.5
       parent: 2
   - uid: 5651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,0.5
       parent: 2
   - uid: 5685
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,9.5
       parent: 2
   - uid: 5857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,5.5
       parent: 2
   - uid: 6711
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-10.5
       parent: 2
   - uid: 6712
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-14.5
       parent: 2
   - uid: 7313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,28.5
       parent: 2
   - uid: 7314
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,33.5
       parent: 2
   - uid: 7315
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,23.5
       parent: 2
   - uid: 7316
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,23.5
       parent: 2
   - uid: 7319
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,26.5
       parent: 2
   - uid: 7320
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,23.5
       parent: 2
   - uid: 7322
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,23.5
       parent: 2
   - uid: 7323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,23.5
       parent: 2
   - uid: 7396
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,33.5
       parent: 2
   - uid: 7397
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,29.5
       parent: 2
   - uid: 7398
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,29.5
       parent: 2
   - uid: 7401
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,33.5
       parent: 2
   - uid: 7402
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,31.5
       parent: 2
   - uid: 7466
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,19.5
       parent: 2
   - uid: 7467
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,19.5
       parent: 2
   - uid: 7613
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,-37.5
       parent: 2
   - uid: 7698
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,45.5
       parent: 2
   - uid: 7700
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,53.5
       parent: 2
   - uid: 7701
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,53.5
       parent: 2
   - uid: 7709
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,47.5
       parent: 2
   - uid: 7710
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,47.5
       parent: 2
   - uid: 7711
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,45.5
       parent: 2
   - uid: 7712
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,49.5
       parent: 2
   - uid: 7713
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,49.5
       parent: 2
   - uid: 7780
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,46.5
       parent: 2
   - uid: 7847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,37.5
       parent: 2
   - uid: 7848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,37.5
       parent: 2
   - uid: 8096
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-11.5
       parent: 2
   - uid: 8684
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,29.5
       parent: 2
   - uid: 8868
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,32.5
       parent: 2
   - uid: 8872
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,37.5
       parent: 2
   - uid: 8947
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,35.5
       parent: 2
   - uid: 8957
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,39.5
       parent: 2
   - uid: 9123
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,41.5
       parent: 2
   - uid: 9238
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-17.5
       parent: 2
   - uid: 9269
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,0.5
       parent: 2
   - uid: 9422
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-11.5
       parent: 2
   - uid: 9528
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-8.5
       parent: 2
   - uid: 9561
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-5.5
       parent: 2
   - uid: 9562
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,-5.5
       parent: 2
   - uid: 9563
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-0.5
       parent: 2
   - uid: 9564
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-0.5
       parent: 2
   - uid: 9776
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,27.5
       parent: 2
   - uid: 9794
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,18.5
       parent: 2
   - uid: 9822
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,25.5
       parent: 2
   - uid: 9827
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,25.5
       parent: 2
   - uid: 9937
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-49.5
       parent: 2
   - uid: 9965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,29.5
       parent: 2
   - uid: 10025
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,29.5
       parent: 2
   - uid: 10454
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,23.5
       parent: 2
   - uid: 10455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.5,23.5
       parent: 2
   - uid: 10470
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,26.5
       parent: 2
   - uid: 11051
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,38.5
       parent: 2
   - uid: 11158
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-17.5
       parent: 2
   - uid: 11159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-13.5
       parent: 2
   - uid: 11410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-27.5
       parent: 2
   - uid: 11794
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-51.5
       parent: 2
   - uid: 11796
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-51.5
       parent: 2
   - uid: 11997
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,23.5
       parent: 2
-  - uid: 12349
-    components:
-    - type: MetaData
-      flags: PvsPriority
-    - type: Transform
-      pos: -43.5,44.5
-      parent: 2
   - uid: 12393
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,44.5
       parent: 2
   - uid: 12620
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,37.5
       parent: 2
   - uid: 12873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,27.5
       parent: 2
   - uid: 12882
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,27.5
       parent: 2
   - uid: 12939
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,18.5
       parent: 2
   - uid: 12981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,21.5
       parent: 2
   - uid: 13121
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,20.5
       parent: 2
   - uid: 13208
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,15.5
       parent: 2
   - uid: 13209
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,15.5
       parent: 2
   - uid: 13213
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-49.5
       parent: 2
   - uid: 13267
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,25.5
       parent: 2
   - uid: 13269
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,33.5
       parent: 2
   - uid: 13330
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,44.5
       parent: 2
   - uid: 13332
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,44.5
       parent: 2
   - uid: 13333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,44.5
       parent: 2
   - uid: 13334
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,44.5
       parent: 2
   - uid: 13552
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -51.5,33.5
       parent: 2
   - uid: 13643
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,38.5
       parent: 2
   - uid: 14271
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,13.5
       parent: 2
   - uid: 14273
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,13.5
       parent: 2
   - uid: 14274
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,9.5
       parent: 2
   - uid: 14275
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,9.5
       parent: 2
   - uid: 14276
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,7.5
       parent: 2
   - uid: 14279
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,8.5
       parent: 2
   - uid: 14280
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,7.5
       parent: 2
   - uid: 14289
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,14.5
       parent: 2
   - uid: 14290
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,15.5
       parent: 2
   - uid: 14562
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-34.5
       parent: 2
   - uid: 14587
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-34.5
       parent: 2
   - uid: 14787
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 14719
   - uid: 14788
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 14719
   - uid: 14789
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 14719
   - uid: 14790
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 14719
   - uid: 14922
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-58.5
       parent: 2
   - uid: 14923
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-58.5
       parent: 2
   - uid: 14927
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-44.5
       parent: 2
   - uid: 14928
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-50.5
       parent: 2
   - uid: 14944
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-63.5
       parent: 2
   - uid: 15042
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-63.5
       parent: 2
   - uid: 15356
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,20.5
       parent: 2
   - uid: 15577
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-25.5
       parent: 2
   - uid: 15930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 2
   - uid: 16270
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,42.5
       parent: 2
   - uid: 16966
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,18.5
       parent: 2
   - uid: 17035
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,18.5
       parent: 2
   - uid: 17036
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,18.5
       parent: 2
   - uid: 17037
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,20.5
       parent: 2
   - uid: 17038
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,23.5
       parent: 2
   - uid: 17557
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-34.5
@@ -75733,6 +74719,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-44.5
       parent: 2
+- proto: PrinterDoc
+  entities:
+  - uid: 11969
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,0.5
+      parent: 2
 - proto: Protolathe
   entities:
   - uid: 2850
@@ -75962,11 +74956,6 @@ entities:
     components:
     - type: Transform
       pos: -84.5,-2.5
-      parent: 2
-  - uid: 16979
-    components:
-    - type: Transform
-      pos: -61.5,32.5
       parent: 2
 - proto: RadioHandheld
   entities:
@@ -77695,40 +76684,45 @@ entities:
     - type: Transform
       pos: -48.5,41.5
       parent: 2
-  - uid: 9497
-    components:
-    - type: Transform
-      pos: -40.5,43.5
-      parent: 2
-  - uid: 9498
-    components:
-    - type: Transform
-      pos: -39.5,43.5
-      parent: 2
-  - uid: 10356
+  - uid: 10107
     components:
     - type: Transform
       pos: -34.5,43.5
       parent: 2
-  - uid: 10520
+  - uid: 10109
     components:
     - type: Transform
       pos: -35.5,43.5
       parent: 2
-  - uid: 10521
+  - uid: 10119
     components:
     - type: Transform
-      pos: -36.5,43.5
+      pos: -39.5,43.5
+      parent: 2
+  - uid: 10461
+    components:
+    - type: Transform
+      pos: -38.5,43.5
       parent: 2
   - uid: 10712
     components:
     - type: Transform
       pos: -47.5,41.5
       parent: 2
+  - uid: 11085
+    components:
+    - type: Transform
+      pos: -36.5,43.5
+      parent: 2
   - uid: 11799
     components:
     - type: Transform
       pos: -47.5,38.5
+      parent: 2
+  - uid: 11943
+    components:
+    - type: Transform
+      pos: -40.5,43.5
       parent: 2
   - uid: 13066
     components:
@@ -77759,26 +76753,6 @@ entities:
     components:
     - type: Transform
       pos: -46.5,43.5
-      parent: 2
-  - uid: 13117
-    components:
-    - type: Transform
-      pos: -44.5,43.5
-      parent: 2
-  - uid: 13118
-    components:
-    - type: Transform
-      pos: -42.5,43.5
-      parent: 2
-  - uid: 13119
-    components:
-    - type: Transform
-      pos: -43.5,43.5
-      parent: 2
-  - uid: 13120
-    components:
-    - type: Transform
-      pos: -38.5,43.5
       parent: 2
 - proto: ReinforcedUraniumWindow
   entities:
@@ -78351,15 +77325,17 @@ entities:
       parent: 2
 - proto: ReinforcedWindowDiagonal
   entities:
-  - uid: 2398
+  - uid: 10123
     components:
     - type: Transform
-      pos: -24.5,-63.5
-      parent: 2
-  - uid: 2414
-    components:
-    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -32.5,-63.5
+      parent: 2
+  - uid: 10521
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-63.5
       parent: 2
 - proto: RemoteSignaller
   entities:
@@ -78441,8 +77417,6 @@ entities:
   entities:
   - uid: 911
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -78452,8 +77426,6 @@ entities:
   entities:
   - uid: 988
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 902
     - type: Physics
@@ -78713,8 +77685,6 @@ entities:
   entities:
   - uid: 767
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78722,8 +77692,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 769
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78761,16 +77729,39 @@ entities:
       parent: 2
 - proto: SheetPlasma
   entities:
-  - uid: 2743
-    components:
-    - type: Transform
-      pos: -61.49986,32.40898
-      parent: 2
   - uid: 5527
     components:
     - type: Transform
       pos: 29.519913,19.558588
       parent: 2
+  - uid: 13109
+    components:
+    - type: Transform
+      parent: 13108
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 13110
+    components:
+    - type: Transform
+      parent: 13108
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 13111
+    components:
+    - type: Transform
+      parent: 13108
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 13112
+    components:
+    - type: Transform
+      parent: 13108
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: SheetPlasma1
   entities:
   - uid: 5528
@@ -78787,8 +77778,6 @@ entities:
   entities:
   - uid: 763
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78796,8 +77785,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 764
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78839,8 +77826,6 @@ entities:
   entities:
   - uid: 768
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78848,8 +77833,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 770
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78864,8 +77847,6 @@ entities:
   entities:
   - uid: 762
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78873,8 +77854,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 765
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 761
     - type: Physics
@@ -78882,8 +77861,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 2353
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3226
     - type: Physics
@@ -78891,8 +77868,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 2373
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12157
     - type: Physics
@@ -78910,8 +77885,6 @@ entities:
       parent: 2
   - uid: 2944
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12163
     - type: Physics
@@ -78947,11 +77920,6 @@ entities:
     - type: Transform
       pos: 11.49087,52.57775
       parent: 2
-  - uid: 12316
-    components:
-    - type: Transform
-      pos: -39.56256,37.533073
-      parent: 2
   - uid: 14484
     components:
     - type: Transform
@@ -78961,13 +77929,16 @@ entities:
   entities:
   - uid: 147
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 1535
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+  - uid: 10128
+    components:
+    - type: Transform
+      pos: -42.480858,34.563686
+      parent: 2
 - proto: ShippingContainerKosmologistika
   entities:
   - uid: 15118
@@ -79427,6 +78398,26 @@ entities:
         - Pressed: Toggle
         5296:
         - Pressed: Toggle
+  - uid: 10115
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -53.5,41.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        13040:
+        - Pressed: Toggle
+  - uid: 10126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -45.5,41.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        10357:
+        - Pressed: Toggle
   - uid: 14631
     components:
     - type: Transform
@@ -79481,6 +78472,9 @@ entities:
       parent: 2
     - type: GasValve
       open: False
+    - type: DeviceLinkSink
+      links:
+      - 10126
     - type: AtmosDevice
       joinedGrid: 2
   - uid: 13040
@@ -79490,6 +78484,9 @@ entities:
       parent: 2
     - type: GasValve
       open: False
+    - type: DeviceLinkSink
+      links:
+      - 10115
     - type: AtmosDevice
       joinedGrid: 2
 - proto: SignAnomaly
@@ -80328,8 +79325,6 @@ entities:
       parent: 2
   - uid: 13217
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -80337,8 +79332,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 13220
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics
@@ -81159,8 +80152,6 @@ entities:
   entities:
   - uid: 15501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-3.5
@@ -81326,10 +80317,10 @@ entities:
       parent: 2
 - proto: SpawnMobCrabAtmos
   entities:
-  - uid: 13305
+  - uid: 13105
     components:
     - type: Transform
-      pos: -39.5,23.5
+      pos: -39.5,27.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:
@@ -81903,13 +80894,6 @@ entities:
     - type: Transform
       pos: -38.5,-10.5
       parent: 2
-- proto: SpawnVehicleJanicart
-  entities:
-  - uid: 461
-    components:
-    - type: Transform
-      pos: 0.5,-13.5
-      parent: 2
 - proto: SpeedLoaderCap
   entities:
   - uid: 3334
@@ -81940,8 +80924,6 @@ entities:
       parent: 2
   - uid: 7379
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7374
     - type: Physics
@@ -82168,13 +81150,6 @@ entities:
     components:
     - type: Transform
       pos: 21.802896,-17.423296
-      parent: 2
-- proto: SpyCrewMonitor
-  entities:
-  - uid: 11064
-    components:
-    - type: Transform
-      pos: -9.446462,7.6160793
       parent: 2
 - proto: Stairs
   entities:
@@ -82906,31 +81881,10 @@ entities:
       parent: 2
 - proto: StorageCanister
   entities:
-  - uid: 10738
-    components:
-    - type: Transform
-      pos: -35.5,44.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
   - uid: 11798
     components:
     - type: Transform
       pos: -38.5,32.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 13060
-    components:
-    - type: Transform
-      pos: -43.5,44.5
-      parent: 2
-    - type: AtmosDevice
-      joinedGrid: 2
-  - uid: 13071
-    components:
-    - type: Transform
-      pos: -39.5,44.5
       parent: 2
     - type: AtmosDevice
       joinedGrid: 2
@@ -83052,8 +82006,6 @@ entities:
   entities:
   - uid: 1546
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3565
     - type: Physics
@@ -84951,11 +83903,6 @@ entities:
     - type: Transform
       pos: 13.5,-9.5
       parent: 2
-  - uid: 538
-    components:
-    - type: Transform
-      pos: -13.5,0.5
-      parent: 2
   - uid: 543
     components:
     - type: Transform
@@ -85405,17 +84352,17 @@ entities:
       parent: 2
 - proto: TeslaCoil
   entities:
+  - uid: 3504
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -63.5,29.5
+      parent: 2
   - uid: 3852
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -62.5,29.5
-      parent: 2
-  - uid: 3947
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -61.5,29.5
       parent: 2
 - proto: TeslaGenerator
   entities:
@@ -85517,8 +84464,6 @@ entities:
   entities:
   - uid: 50
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,1.5
       parent: 2
@@ -85731,8 +84676,6 @@ entities:
   entities:
   - uid: 12976
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12936
     - type: Physics
@@ -85763,8 +84706,6 @@ entities:
   entities:
   - uid: 5397
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3226
     - type: Physics
@@ -85772,8 +84713,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 12162
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12157
     - type: Physics
@@ -85781,8 +84720,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 12166
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12163
     - type: Physics
@@ -85868,8 +84805,6 @@ entities:
   entities:
   - uid: 9260
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 9259
     - type: Physics
@@ -85915,30 +84850,6 @@ entities:
     - type: Transform
       rot: -6.283185307179586 rad
       pos: 33.522274,9.641938
-      parent: 2
-- proto: VehicleKeyJanicart
-  entities:
-  - uid: 435
-    components:
-    - type: MetaData
-      flags: InContainer
-    - type: Transform
-      parent: 185
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 6676
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.4373233,-11.372094
-      parent: 2
-- proto: VehicleKeySyndicateSegway
-  entities:
-  - uid: 7626
-    components:
-    - type: Transform
-      pos: -78.24632,-13.096848
       parent: 2
 - proto: VendingBarDrobe
   entities:
@@ -86089,6 +85000,13 @@ entities:
     components:
     - type: Transform
       pos: 8.5,0.5
+      parent: 2
+- proto: VendingMachineGeneDrobe
+  entities:
+  - uid: 10116
+    components:
+    - type: Transform
+      pos: 18.5,-42.5
       parent: 2
 - proto: VendingMachineHappyHonk
   entities:
@@ -86332,1604 +85250,1146 @@ entities:
   entities:
   - uid: 1121
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-58.5
       parent: 2
   - uid: 1223
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-34.5
       parent: 2
   - uid: 1224
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-38.5
       parent: 2
   - uid: 1244
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-34.5
       parent: 2
   - uid: 1250
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-38.5
       parent: 2
   - uid: 1293
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-37.5
       parent: 2
   - uid: 1313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-38.5
       parent: 2
   - uid: 1344
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-38.5
       parent: 2
   - uid: 1351
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-37.5
       parent: 2
   - uid: 1387
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-35.5
       parent: 2
   - uid: 1636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-48.5
       parent: 2
   - uid: 1643
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-52.5
       parent: 2
   - uid: 1675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-50.5
       parent: 2
   - uid: 1676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-52.5
       parent: 2
   - uid: 1714
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-52.5
       parent: 2
   - uid: 1974
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-47.5
       parent: 2
   - uid: 2007
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-19.5
       parent: 2
   - uid: 2009
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-20.5
       parent: 2
   - uid: 2010
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-18.5
       parent: 2
   - uid: 2011
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-21.5
       parent: 2
   - uid: 2013
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-22.5
       parent: 2
   - uid: 2016
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-17.5
       parent: 2
   - uid: 2017
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-17.5
       parent: 2
   - uid: 2018
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-17.5
       parent: 2
   - uid: 2019
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-17.5
       parent: 2
   - uid: 2020
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-17.5
       parent: 2
   - uid: 2024
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-31.5
       parent: 2
   - uid: 2025
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-35.5
       parent: 2
   - uid: 2029
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-30.5
       parent: 2
   - uid: 2036
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-16.5
       parent: 2
   - uid: 2043
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-31.5
       parent: 2
   - uid: 2044
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-32.5
       parent: 2
   - uid: 2045
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-31.5
       parent: 2
   - uid: 2047
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-25.5
       parent: 2
   - uid: 2049
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-30.5
       parent: 2
   - uid: 2050
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-31.5
       parent: 2
   - uid: 2052
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-31.5
       parent: 2
   - uid: 2053
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-31.5
       parent: 2
   - uid: 2054
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-22.5
       parent: 2
   - uid: 2057
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-22.5
       parent: 2
   - uid: 2061
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-25.5
       parent: 2
   - uid: 2062
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-26.5
       parent: 2
   - uid: 2063
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-25.5
       parent: 2
   - uid: 2064
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-25.5
       parent: 2
   - uid: 2065
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-25.5
       parent: 2
   - uid: 2066
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-25.5
       parent: 2
   - uid: 2067
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-25.5
       parent: 2
   - uid: 2068
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-29.5
       parent: 2
   - uid: 2070
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-27.5
       parent: 2
   - uid: 2071
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-26.5
       parent: 2
   - uid: 2072
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-25.5
       parent: 2
   - uid: 2073
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-33.5
       parent: 2
   - uid: 2074
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-33.5
       parent: 2
   - uid: 2077
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-33.5
       parent: 2
   - uid: 2078
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-33.5
       parent: 2
   - uid: 2079
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-34.5
       parent: 2
   - uid: 2080
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-34.5
       parent: 2
   - uid: 2081
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-34.5
       parent: 2
   - uid: 2082
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-34.5
       parent: 2
   - uid: 2083
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-35.5
       parent: 2
   - uid: 2086
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-38.5
       parent: 2
   - uid: 2087
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-39.5
       parent: 2
   - uid: 2088
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-39.5
       parent: 2
   - uid: 2089
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-39.5
       parent: 2
   - uid: 2092
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-39.5
       parent: 2
   - uid: 2093
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-39.5
       parent: 2
   - uid: 2094
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-39.5
       parent: 2
   - uid: 2095
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-38.5
       parent: 2
   - uid: 2098
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-35.5
       parent: 2
   - uid: 2135
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-16.5
       parent: 2
   - uid: 2136
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-16.5
       parent: 2
   - uid: 2137
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-16.5
       parent: 2
   - uid: 2138
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-16.5
       parent: 2
   - uid: 2139
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-16.5
       parent: 2
   - uid: 2140
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-16.5
       parent: 2
   - uid: 2141
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-16.5
       parent: 2
   - uid: 2142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-16.5
       parent: 2
   - uid: 2143
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-17.5
       parent: 2
   - uid: 2145
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-19.5
       parent: 2
   - uid: 2146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-20.5
       parent: 2
   - uid: 2147
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-20.5
       parent: 2
   - uid: 2148
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-20.5
       parent: 2
   - uid: 2149
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-20.5
       parent: 2
   - uid: 2150
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-20.5
       parent: 2
   - uid: 2151
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-20.5
       parent: 2
   - uid: 2153
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-20.5
       parent: 2
   - uid: 2154
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-20.5
       parent: 2
   - uid: 2155
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-19.5
       parent: 2
   - uid: 2156
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-18.5
       parent: 2
   - uid: 2158
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-17.5
       parent: 2
   - uid: 2189
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-31.5
       parent: 2
   - uid: 2190
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-31.5
       parent: 2
   - uid: 2191
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-31.5
       parent: 2
   - uid: 2192
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-30.5
       parent: 2
   - uid: 2193
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-26.5
       parent: 2
   - uid: 2194
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-25.5
       parent: 2
   - uid: 2195
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-25.5
       parent: 2
   - uid: 2196
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-25.5
       parent: 2
   - uid: 2197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-25.5
       parent: 2
   - uid: 2198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-25.5
       parent: 2
   - uid: 2199
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-25.5
       parent: 2
   - uid: 2200
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-25.5
       parent: 2
   - uid: 2201
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-25.5
       parent: 2
   - uid: 2202
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-26.5
       parent: 2
   - uid: 2203
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-27.5
       parent: 2
   - uid: 2204
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-28.5
       parent: 2
   - uid: 2206
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-30.5
       parent: 2
   - uid: 2207
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-31.5
       parent: 2
   - uid: 2208
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-31.5
       parent: 2
   - uid: 2209
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-31.5
       parent: 2
   - uid: 3076
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-45.5
       parent: 2
   - uid: 3077
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-46.5
       parent: 2
   - uid: 3078
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-47.5
       parent: 2
   - uid: 3079
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-48.5
       parent: 2
   - uid: 3082
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-51.5
       parent: 2
   - uid: 3083
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-52.5
       parent: 2
   - uid: 3084
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-53.5
       parent: 2
   - uid: 3085
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-45.5
       parent: 2
   - uid: 3086
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-46.5
       parent: 2
   - uid: 3087
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-47.5
       parent: 2
   - uid: 3088
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-48.5
       parent: 2
   - uid: 3090
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-49.5
       parent: 2
   - uid: 3092
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-52.5
       parent: 2
   - uid: 3093
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-53.5
       parent: 2
   - uid: 3103
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-53.5
       parent: 2
   - uid: 3106
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-53.5
       parent: 2
   - uid: 3107
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-54.5
       parent: 2
   - uid: 3108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-54.5
       parent: 2
   - uid: 3109
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-54.5
       parent: 2
   - uid: 3110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-54.5
       parent: 2
   - uid: 3111
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-54.5
       parent: 2
   - uid: 3112
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-55.5
       parent: 2
   - uid: 3113
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-56.5
       parent: 2
   - uid: 3114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-57.5
       parent: 2
   - uid: 3115
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-57.5
       parent: 2
   - uid: 3116
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-57.5
       parent: 2
   - uid: 3117
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-57.5
       parent: 2
   - uid: 3118
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-57.5
       parent: 2
   - uid: 3122
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-58.5
       parent: 2
   - uid: 3123
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-58.5
       parent: 2
   - uid: 3124
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-58.5
       parent: 2
   - uid: 3125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-58.5
       parent: 2
   - uid: 3126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-58.5
       parent: 2
   - uid: 3127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-58.5
       parent: 2
   - uid: 3128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-57.5
       parent: 2
   - uid: 3130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-57.5
       parent: 2
   - uid: 3131
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-57.5
       parent: 2
   - uid: 3132
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-57.5
       parent: 2
   - uid: 3133
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-57.5
       parent: 2
   - uid: 3134
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-56.5
       parent: 2
   - uid: 3135
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-55.5
       parent: 2
   - uid: 3136
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-54.5
       parent: 2
   - uid: 3137
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-54.5
       parent: 2
   - uid: 3138
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-54.5
       parent: 2
   - uid: 3139
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-54.5
       parent: 2
   - uid: 3140
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-54.5
       parent: 2
   - uid: 3141
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-53.5
       parent: 2
   - uid: 3142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-53.5
       parent: 2
   - uid: 3161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-52.5
       parent: 2
   - uid: 3162
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-49.5
       parent: 2
   - uid: 3164
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-51.5
       parent: 2
   - uid: 3165
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-52.5
       parent: 2
   - uid: 3169
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-32.5
       parent: 2
   - uid: 3176
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-38.5
       parent: 2
   - uid: 3178
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-37.5
       parent: 2
   - uid: 3179
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-38.5
       parent: 2
   - uid: 3180
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-38.5
       parent: 2
   - uid: 3182
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-37.5
       parent: 2
   - uid: 3183
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-37.5
       parent: 2
   - uid: 3184
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-38.5
       parent: 2
   - uid: 3186
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-41.5
       parent: 2
   - uid: 3187
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-41.5
       parent: 2
   - uid: 3192
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-41.5
       parent: 2
   - uid: 3193
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-41.5
       parent: 2
   - uid: 3195
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-45.5
       parent: 2
   - uid: 3196
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-45.5
       parent: 2
   - uid: 3197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-45.5
       parent: 2
   - uid: 3198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-45.5
       parent: 2
   - uid: 3199
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-45.5
       parent: 2
   - uid: 3200
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-45.5
       parent: 2
   - uid: 3201
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-45.5
       parent: 2
   - uid: 3202
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-45.5
       parent: 2
   - uid: 3206
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-42.5
       parent: 2
   - uid: 3207
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-43.5
       parent: 2
   - uid: 3208
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-44.5
       parent: 2
   - uid: 3237
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-42.5
       parent: 2
   - uid: 3240
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-44.5
       parent: 2
   - uid: 3360
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-58.5
       parent: 2
   - uid: 3578
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-49.5
       parent: 2
   - uid: 3579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-53.5
       parent: 2
   - uid: 3580
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-53.5
       parent: 2
   - uid: 3742
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-37.5
       parent: 2
   - uid: 3864
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-37.5
       parent: 2
   - uid: 3866
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-34.5
       parent: 2
   - uid: 3868
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-37.5
       parent: 2
   - uid: 4047
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-39.5
       parent: 2
   - uid: 4297
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-47.5
       parent: 2
   - uid: 4346
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-20.5
       parent: 2
   - uid: 4357
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-22.5
       parent: 2
   - uid: 4367
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-34.5
       parent: 2
   - uid: 5301
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-33.5
       parent: 2
   - uid: 10735
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-51.5
       parent: 2
   - uid: 11818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-48.5
       parent: 2
   - uid: 11850
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-48.5
       parent: 2
   - uid: 12049
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-53.5
       parent: 2
   - uid: 12071
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-53.5
       parent: 2
   - uid: 12075
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-53.5
       parent: 2
   - uid: 12118
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-53.5
       parent: 2
   - uid: 12143
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-52.5
       parent: 2
   - uid: 12159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-48.5
       parent: 2
   - uid: 12161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-47.5
       parent: 2
   - uid: 12165
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-47.5
       parent: 2
   - uid: 12193
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-52.5
       parent: 2
   - uid: 12195
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-48.5
       parent: 2
   - uid: 12208
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-47.5
       parent: 2
   - uid: 12214
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-52.5
       parent: 2
   - uid: 12326
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-50.5
       parent: 2
   - uid: 12355
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-49.5
       parent: 2
   - uid: 12356
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-48.5
       parent: 2
   - uid: 12361
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-51.5
       parent: 2
   - uid: 12425
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-48.5
       parent: 2
   - uid: 12489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-53.5
       parent: 2
   - uid: 12607
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-53.5
       parent: 2
   - uid: 12608
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-48.5
       parent: 2
   - uid: 12611
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-47.5
       parent: 2
   - uid: 14585
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-32.5
       parent: 2
   - uid: 14586
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-33.5
       parent: 2
   - uid: 15732
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-32.5
       parent: 2
   - uid: 16720
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-22.5
       parent: 2
@@ -87937,1387 +86397,991 @@ entities:
   entities:
   - uid: 87
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,28.5
       parent: 2
   - uid: 1655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,10.5
       parent: 2
   - uid: 2733
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,25.5
       parent: 2
   - uid: 3292
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,24.5
       parent: 2
   - uid: 3293
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,24.5
       parent: 2
   - uid: 3305
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,24.5
       parent: 2
   - uid: 3348
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,24.5
       parent: 2
   - uid: 3370
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,24.5
       parent: 2
   - uid: 3374
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,24.5
       parent: 2
   - uid: 3390
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,27.5
       parent: 2
   - uid: 3391
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,28.5
       parent: 2
   - uid: 3423
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,28.5
       parent: 2
   - uid: 3459
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,28.5
       parent: 2
   - uid: 3460
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,28.5
       parent: 2
   - uid: 3462
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,28.5
       parent: 2
   - uid: 5786
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,24.5
       parent: 2
   - uid: 7037
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,17.5
       parent: 2
   - uid: 7038
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,17.5
       parent: 2
   - uid: 7039
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,17.5
       parent: 2
   - uid: 7042
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,17.5
       parent: 2
   - uid: 7049
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,16.5
       parent: 2
   - uid: 7050
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,17.5
       parent: 2
   - uid: 7160
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,17.5
       parent: 2
   - uid: 8170
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,17.5
       parent: 2
   - uid: 8179
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,18.5
       parent: 2
   - uid: 8185
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,16.5
       parent: 2
   - uid: 8727
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,17.5
       parent: 2
   - uid: 8739
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,16.5
       parent: 2
   - uid: 8851
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,28.5
       parent: 2
   - uid: 8853
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,25.5
       parent: 2
   - uid: 8856
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,26.5
       parent: 2
   - uid: 8997
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,18.5
       parent: 2
   - uid: 9000
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,23.5
       parent: 2
   - uid: 9002
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,28.5
       parent: 2
   - uid: 9003
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,25.5
       parent: 2
   - uid: 9006
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,27.5
       parent: 2
   - uid: 9009
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,28.5
       parent: 2
   - uid: 9010
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,28.5
       parent: 2
   - uid: 9011
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,28.5
       parent: 2
   - uid: 9012
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,28.5
       parent: 2
   - uid: 9013
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,26.5
       parent: 2
   - uid: 9029
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,24.5
       parent: 2
   - uid: 9258
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,15.5
       parent: 2
   - uid: 9265
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,11.5
       parent: 2
   - uid: 9266
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,12.5
       parent: 2
   - uid: 9267
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,13.5
       parent: 2
   - uid: 9268
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,14.5
       parent: 2
   - uid: 9323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,24.5
       parent: 2
   - uid: 9378
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,21.5
       parent: 2
   - uid: 9482
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,28.5
       parent: 2
   - uid: 9688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,24.5
       parent: 2
   - uid: 9689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,24.5
       parent: 2
   - uid: 9690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,24.5
       parent: 2
   - uid: 9694
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,24.5
       parent: 2
   - uid: 9739
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,24.5
       parent: 2
   - uid: 9746
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,22.5
       parent: 2
   - uid: 9770
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,24.5
       parent: 2
   - uid: 9780
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,17.5
       parent: 2
   - uid: 9781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,17.5
       parent: 2
   - uid: 9783
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,17.5
       parent: 2
   - uid: 9784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,17.5
       parent: 2
   - uid: 9785
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,17.5
       parent: 2
   - uid: 9786
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,18.5
       parent: 2
   - uid: 9788
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,17.5
       parent: 2
   - uid: 9789
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,17.5
       parent: 2
   - uid: 9790
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,17.5
       parent: 2
   - uid: 9793
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,17.5
       parent: 2
   - uid: 9798
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,23.5
       parent: 2
   - uid: 9810
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,24.5
       parent: 2
   - uid: 9814
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,18.5
       parent: 2
   - uid: 9818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,24.5
       parent: 2
   - uid: 9819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,23.5
       parent: 2
   - uid: 9830
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,24.5
       parent: 2
   - uid: 9833
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,22.5
       parent: 2
   - uid: 9834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,21.5
       parent: 2
   - uid: 9863
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,25.5
       parent: 2
   - uid: 9895
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,21.5
       parent: 2
   - uid: 9896
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,27.5
       parent: 2
   - uid: 9897
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,21.5
       parent: 2
   - uid: 9898
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,21.5
       parent: 2
   - uid: 9899
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,21.5
       parent: 2
   - uid: 9904
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,21.5
       parent: 2
   - uid: 9905
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,21.5
       parent: 2
   - uid: 9911
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,21.5
       parent: 2
   - uid: 9912
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,21.5
       parent: 2
   - uid: 9913
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,21.5
       parent: 2
   - uid: 9914
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,21.5
       parent: 2
   - uid: 9915
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,21.5
       parent: 2
   - uid: 9916
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,21.5
       parent: 2
   - uid: 9918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,18.5
       parent: 2
   - uid: 9921
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,18.5
       parent: 2
   - uid: 9922
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,18.5
       parent: 2
   - uid: 9923
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,18.5
       parent: 2
   - uid: 9924
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,18.5
       parent: 2
   - uid: 9930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,18.5
       parent: 2
   - uid: 9940
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,18.5
       parent: 2
   - uid: 9941
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,17.5
       parent: 2
   - uid: 9942
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,18.5
       parent: 2
   - uid: 9943
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,17.5
       parent: 2
   - uid: 9945
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,16.5
       parent: 2
   - uid: 9947
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,16.5
       parent: 2
   - uid: 9948
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,16.5
       parent: 2
   - uid: 9949
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,16.5
       parent: 2
   - uid: 9950
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,16.5
       parent: 2
   - uid: 9951
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,16.5
       parent: 2
   - uid: 9952
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,16.5
       parent: 2
   - uid: 9953
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,16.5
       parent: 2
   - uid: 9954
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,15.5
       parent: 2
   - uid: 9955
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,13.5
       parent: 2
   - uid: 9956
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,12.5
       parent: 2
   - uid: 9957
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,11.5
       parent: 2
   - uid: 9958
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,10.5
       parent: 2
   - uid: 9966
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,10.5
       parent: 2
   - uid: 9967
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,11.5
       parent: 2
   - uid: 9968
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,12.5
       parent: 2
   - uid: 9969
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,13.5
       parent: 2
   - uid: 9970
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,14.5
       parent: 2
   - uid: 9971
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,15.5
       parent: 2
   - uid: 9978
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,14.5
       parent: 2
   - uid: 9980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,11.5
       parent: 2
   - uid: 9981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,13.5
       parent: 2
   - uid: 9983
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,12.5
       parent: 2
   - uid: 9984
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,15.5
       parent: 2
   - uid: 9986
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,16.5
       parent: 2
   - uid: 9999
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,26.5
       parent: 2
   - uid: 10003
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,23.5
       parent: 2
   - uid: 10004
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,22.5
       parent: 2
   - uid: 10016
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,24.5
       parent: 2
   - uid: 10017
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,22.5
       parent: 2
   - uid: 10019
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,24.5
       parent: 2
   - uid: 10020
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,24.5
       parent: 2
   - uid: 10041
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,24.5
       parent: 2
   - uid: 10044
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,21.5
       parent: 2
   - uid: 10062
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,10.5
       parent: 2
   - uid: 10063
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,10.5
       parent: 2
   - uid: 10064
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,10.5
       parent: 2
   - uid: 10065
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,10.5
       parent: 2
   - uid: 10066
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,10.5
       parent: 2
   - uid: 10067
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,10.5
       parent: 2
   - uid: 10068
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,10.5
       parent: 2
   - uid: 10161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,28.5
       parent: 2
   - uid: 10192
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,23.5
       parent: 2
   - uid: 10197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,24.5
       parent: 2
   - uid: 10198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,26.5
       parent: 2
   - uid: 10199
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,25.5
       parent: 2
   - uid: 10200
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,24.5
       parent: 2
   - uid: 10394
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,28.5
       parent: 2
   - uid: 10535
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,27.5
       parent: 2
   - uid: 10752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,18.5
       parent: 2
   - uid: 10753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,21.5
       parent: 2
   - uid: 10759
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,22.5
       parent: 2
   - uid: 10764
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,30.5
       parent: 2
   - uid: 10765
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,31.5
       parent: 2
   - uid: 10766
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,28.5
       parent: 2
   - uid: 10770
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,28.5
       parent: 2
   - uid: 10777
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,23.5
       parent: 2
   - uid: 10778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,24.5
       parent: 2
   - uid: 10779
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,25.5
       parent: 2
   - uid: 10780
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,26.5
       parent: 2
   - uid: 10781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,27.5
       parent: 2
   - uid: 10782
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,28.5
       parent: 2
   - uid: 10783
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,28.5
       parent: 2
   - uid: 10784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,29.5
       parent: 2
   - uid: 10785
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,30.5
       parent: 2
   - uid: 10786
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,31.5
       parent: 2
   - uid: 10787
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,32.5
       parent: 2
   - uid: 10788
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,33.5
       parent: 2
   - uid: 10796
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,33.5
       parent: 2
   - uid: 10797
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,29.5
       parent: 2
   - uid: 10800
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,28.5
       parent: 2
   - uid: 10801
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,28.5
       parent: 2
   - uid: 10802
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,28.5
       parent: 2
   - uid: 10806
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,22.5
       parent: 2
   - uid: 10807
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,22.5
       parent: 2
   - uid: 10820
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,21.5
       parent: 2
   - uid: 10824
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,33.5
       parent: 2
   - uid: 10825
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,33.5
       parent: 2
   - uid: 10826
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,33.5
       parent: 2
   - uid: 10827
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,33.5
       parent: 2
   - uid: 10840
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,33.5
       parent: 2
   - uid: 10841
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,32.5
       parent: 2
   - uid: 10844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,22.5
       parent: 2
   - uid: 10848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,22.5
       parent: 2
   - uid: 10901
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,22.5
       parent: 2
   - uid: 11028
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,18.5
       parent: 2
   - uid: 11037
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,19.5
       parent: 2
   - uid: 11052
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,10.5
       parent: 2
   - uid: 11053
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,10.5
       parent: 2
   - uid: 11071
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,22.5
       parent: 2
   - uid: 11171
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,10.5
       parent: 2
   - uid: 11642
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,27.5
       parent: 2
   - uid: 11852
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,24.5
       parent: 2
   - uid: 11853
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,24.5
       parent: 2
   - uid: 12377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,10.5
       parent: 2
   - uid: 12918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,17.5
       parent: 2
   - uid: 13337
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,28.5
       parent: 2
   - uid: 13651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,10.5
       parent: 2
   - uid: 13652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,10.5
       parent: 2
@@ -89325,155 +87389,111 @@ entities:
   entities:
   - uid: 3031
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-11.5
       parent: 2
   - uid: 5884
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-13.5
       parent: 2
   - uid: 5915
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-14.5
       parent: 2
   - uid: 5918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-15.5
       parent: 2
   - uid: 6022
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-12.5
       parent: 2
   - uid: 6029
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-16.5
       parent: 2
   - uid: 6486
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-11.5
       parent: 2
   - uid: 7994
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-12.5
       parent: 2
   - uid: 8020
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-16.5
       parent: 2
   - uid: 8024
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-19.5
       parent: 2
   - uid: 8025
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-14.5
       parent: 2
   - uid: 8026
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-11.5
       parent: 2
   - uid: 8027
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-19.5
       parent: 2
   - uid: 8028
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-17.5
       parent: 2
   - uid: 8029
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-15.5
       parent: 2
   - uid: 8038
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-19.5
       parent: 2
   - uid: 8041
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-11.5
       parent: 2
   - uid: 8042
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-13.5
       parent: 2
   - uid: 8046
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-19.5
       parent: 2
   - uid: 8047
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-18.5
       parent: 2
   - uid: 8049
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-17.5
       parent: 2
   - uid: 8051
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-11.5
       parent: 2
@@ -89481,148 +87501,106 @@ entities:
   entities:
   - uid: 8916
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,28.5
       parent: 2
   - uid: 9732
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,27.5
       parent: 2
   - uid: 9733
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,26.5
       parent: 2
   - uid: 9734
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,25.5
       parent: 2
   - uid: 9735
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,24.5
       parent: 2
   - uid: 9736
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,23.5
       parent: 2
   - uid: 9737
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,22.5
       parent: 2
   - uid: 9738
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,21.5
       parent: 2
   - uid: 9740
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,20.5
       parent: 2
   - uid: 9741
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,21.5
       parent: 2
   - uid: 9742
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,22.5
       parent: 2
   - uid: 9743
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,23.5
       parent: 2
   - uid: 9744
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,24.5
       parent: 2
   - uid: 9745
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,25.5
       parent: 2
   - uid: 9747
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,27.5
       parent: 2
   - uid: 9748
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,28.5
       parent: 2
   - uid: 9749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,28.5
       parent: 2
   - uid: 9750
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,28.5
       parent: 2
   - uid: 9751
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,28.5
       parent: 2
   - uid: 9752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,28.5
       parent: 2
   - uid: 9753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,28.5
       parent: 2
@@ -89630,603 +87608,431 @@ entities:
   entities:
   - uid: 1106
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,42.5
       parent: 2
   - uid: 2119
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-24.5
       parent: 2
   - uid: 2120
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-21.5
       parent: 2
   - uid: 2125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,42.5
       parent: 2
   - uid: 2127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,42.5
       parent: 2
   - uid: 2605
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-23.5
       parent: 2
   - uid: 2607
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-22.5
       parent: 2
   - uid: 2639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-23.5
       parent: 2
   - uid: 2640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-24.5
       parent: 2
   - uid: 2647
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-21.5
       parent: 2
   - uid: 2697
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,39.5
       parent: 2
   - uid: 3308
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,41.5
       parent: 2
   - uid: 3536
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,41.5
       parent: 2
   - uid: 5787
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,39.5
       parent: 2
   - uid: 6699
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,33.5
       parent: 2
   - uid: 6705
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,28.5
       parent: 2
   - uid: 8058
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,42.5
       parent: 2
   - uid: 8059
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,42.5
       parent: 2
   - uid: 8060
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,43.5
       parent: 2
   - uid: 8062
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,42.5
       parent: 2
   - uid: 8064
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,41.5
       parent: 2
   - uid: 8067
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,42.5
       parent: 2
   - uid: 8070
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,42.5
       parent: 2
   - uid: 8071
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,42.5
       parent: 2
   - uid: 8075
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,38.5
       parent: 2
   - uid: 8076
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,37.5
       parent: 2
   - uid: 8077
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,36.5
       parent: 2
   - uid: 8078
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,35.5
       parent: 2
   - uid: 8079
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,34.5
       parent: 2
   - uid: 8080
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,34.5
       parent: 2
   - uid: 8081
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,34.5
       parent: 2
   - uid: 8082
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,34.5
       parent: 2
   - uid: 8083
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,34.5
       parent: 2
   - uid: 8084
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,34.5
       parent: 2
   - uid: 8086
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,35.5
       parent: 2
   - uid: 8088
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,37.5
       parent: 2
   - uid: 8090
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,38.5
       parent: 2
   - uid: 8091
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,38.5
       parent: 2
   - uid: 8094
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,38.5
       parent: 2
   - uid: 8137
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,33.5
       parent: 2
   - uid: 8140
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,28.5
       parent: 2
   - uid: 8141
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,28.5
       parent: 2
   - uid: 8142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,28.5
       parent: 2
   - uid: 8143
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,28.5
       parent: 2
   - uid: 8144
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,29.5
       parent: 2
   - uid: 8145
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,30.5
       parent: 2
   - uid: 8146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,31.5
       parent: 2
   - uid: 8147
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,32.5
       parent: 2
   - uid: 8149
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,33.5
       parent: 2
   - uid: 8150
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,33.5
       parent: 2
   - uid: 8674
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,33.5
       parent: 2
   - uid: 8683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,37.5
       parent: 2
   - uid: 8685
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,39.5
       parent: 2
   - uid: 8686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,39.5
       parent: 2
   - uid: 8687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,35.5
       parent: 2
   - uid: 8688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,35.5
       parent: 2
   - uid: 8689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,38.5
       parent: 2
   - uid: 8690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,36.5
       parent: 2
   - uid: 8691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,35.5
       parent: 2
   - uid: 8692
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,35.5
       parent: 2
   - uid: 8695
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,38.5
       parent: 2
   - uid: 8713
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,42.5
       parent: 2
   - uid: 8714
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,42.5
       parent: 2
   - uid: 8715
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,42.5
       parent: 2
   - uid: 8716
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,42.5
       parent: 2
   - uid: 8717
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,42.5
       parent: 2
   - uid: 8718
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,42.5
       parent: 2
   - uid: 8724
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,42.5
       parent: 2
   - uid: 8725
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,42.5
       parent: 2
   - uid: 8740
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,33.5
       parent: 2
   - uid: 8750
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,41.5
       parent: 2
   - uid: 8753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,42.5
       parent: 2
   - uid: 8757
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,43.5
       parent: 2
   - uid: 8834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,34.5
       parent: 2
   - uid: 9023
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,36.5
       parent: 2
   - uid: 11889
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,43.5
       parent: 2
   - uid: 12146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,41.5
       parent: 2
   - uid: 12565
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,43.5
       parent: 2
   - uid: 13525
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,42.5
       parent: 2
   - uid: 13778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-60.5
       parent: 2
   - uid: 14453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-60.5
       parent: 2
   - uid: 14500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-64.5
       parent: 2
   - uid: 14538
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,43.5
       parent: 2
   - uid: 14542
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,43.5
       parent: 2
   - uid: 14976
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-64.5
       parent: 2
   - uid: 15003
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-64.5
       parent: 2
@@ -90346,85 +88152,61 @@ entities:
   entities:
   - uid: 7584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,38.5
       parent: 2
   - uid: 7824
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,40.5
       parent: 2
   - uid: 7826
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,42.5
       parent: 2
   - uid: 7827
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,42.5
       parent: 2
   - uid: 7829
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,38.5
       parent: 2
   - uid: 7830
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,41.5
       parent: 2
   - uid: 7893
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,40.5
       parent: 2
   - uid: 7908
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,39.5
       parent: 2
   - uid: 7911
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,41.5
       parent: 2
   - uid: 7916
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,38.5
       parent: 2
   - uid: 7921
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,39.5
       parent: 2
   - uid: 8139
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,38.5
       parent: 2
@@ -90432,85 +88214,61 @@ entities:
   entities:
   - uid: 2664
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-50.5
       parent: 2
   - uid: 2667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-53.5
       parent: 2
   - uid: 2668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-54.5
       parent: 2
   - uid: 2671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-54.5
       parent: 2
   - uid: 2672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-53.5
       parent: 2
   - uid: 2675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-50.5
       parent: 2
   - uid: 2676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-49.5
       parent: 2
   - uid: 2679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-49.5
       parent: 2
   - uid: 2680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-54.5
       parent: 2
   - uid: 2681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-54.5
       parent: 2
   - uid: 2682
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-49.5
       parent: 2
   - uid: 2683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-49.5
       parent: 2
@@ -90518,750 +88276,536 @@ entities:
   entities:
   - uid: 1940
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,20.5
       parent: 2
   - uid: 1942
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,12.5
       parent: 2
   - uid: 1953
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,18.5
       parent: 2
   - uid: 1954
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,18.5
       parent: 2
   - uid: 1965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,17.5
       parent: 2
   - uid: 3823
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,16.5
       parent: 2
   - uid: 3837
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,18.5
       parent: 2
   - uid: 4065
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,0.5
       parent: 2
   - uid: 4335
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,0.5
       parent: 2
   - uid: 4460
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,10.5
       parent: 2
   - uid: 4780
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-5.5
       parent: 2
   - uid: 4781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-0.5
       parent: 2
   - uid: 4782
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-5.5
       parent: 2
   - uid: 4783
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-0.5
       parent: 2
   - uid: 4784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-3.5
       parent: 2
   - uid: 4785
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-1.5
       parent: 2
   - uid: 4793
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-3.5
       parent: 2
   - uid: 4829
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,3.5
       parent: 2
   - uid: 4873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,13.5
       parent: 2
   - uid: 4878
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,0.5
       parent: 2
   - uid: 4952
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,5.5
       parent: 2
   - uid: 5047
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,5.5
       parent: 2
   - uid: 5048
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,0.5
       parent: 2
   - uid: 5052
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,4.5
       parent: 2
   - uid: 5142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,5.5
       parent: 2
   - uid: 5145
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,5.5
       parent: 2
   - uid: 5146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,5.5
       parent: 2
   - uid: 5147
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,8.5
       parent: 2
   - uid: 5148
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,8.5
       parent: 2
   - uid: 5149
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,8.5
       parent: 2
   - uid: 5150
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,8.5
       parent: 2
   - uid: 5156
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,16.5
       parent: 2
   - uid: 5157
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,16.5
       parent: 2
   - uid: 5158
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,16.5
       parent: 2
   - uid: 5159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-0.5
       parent: 2
   - uid: 5160
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,15.5
       parent: 2
   - uid: 5161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,11.5
       parent: 2
   - uid: 5164
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,10.5
       parent: 2
   - uid: 5165
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,10.5
       parent: 2
   - uid: 5166
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,10.5
       parent: 2
   - uid: 5173
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,18.5
       parent: 2
   - uid: 5174
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,18.5
       parent: 2
   - uid: 5176
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,17.5
       parent: 2
   - uid: 5178
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,11.5
       parent: 2
   - uid: 5181
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,17.5
       parent: 2
   - uid: 5182
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,4.5
       parent: 2
   - uid: 5183
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,4.5
       parent: 2
   - uid: 5188
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-0.5
       parent: 2
   - uid: 5191
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-0.5
       parent: 2
   - uid: 5197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-0.5
       parent: 2
   - uid: 5201
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,4.5
       parent: 2
   - uid: 5207
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,17.5
       parent: 2
   - uid: 5208
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,18.5
       parent: 2
   - uid: 5209
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,20.5
       parent: 2
   - uid: 5210
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,15.5
       parent: 2
   - uid: 5211
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,13.5
       parent: 2
   - uid: 5212
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,19.5
       parent: 2
   - uid: 5213
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,20.5
       parent: 2
   - uid: 5214
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,19.5
       parent: 2
   - uid: 5215
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,20.5
       parent: 2
   - uid: 5216
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,20.5
       parent: 2
   - uid: 5217
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,18.5
       parent: 2
   - uid: 5218
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,20.5
       parent: 2
   - uid: 5219
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,16.5
       parent: 2
   - uid: 5221
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,14.5
       parent: 2
   - uid: 5226
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,4.5
       parent: 2
   - uid: 5229
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,4.5
       parent: 2
   - uid: 5233
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,15.5
       parent: 2
   - uid: 5234
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-3.5
       parent: 2
   - uid: 5238
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,12.5
       parent: 2
   - uid: 5242
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-3.5
       parent: 2
   - uid: 5243
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-4.5
       parent: 2
   - uid: 5244
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,7.5
       parent: 2
   - uid: 5245
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-5.5
       parent: 2
   - uid: 5246
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,9.5
       parent: 2
   - uid: 5247
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,10.5
       parent: 2
   - uid: 5248
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,10.5
       parent: 2
   - uid: 5250
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,10.5
       parent: 2
   - uid: 5254
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,20.5
       parent: 2
   - uid: 5261
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,9.5
       parent: 2
   - uid: 5264
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,5.5
       parent: 2
   - uid: 5265
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,14.5
       parent: 2
   - uid: 5268
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,4.5
       parent: 2
   - uid: 5271
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,9.5
       parent: 2
   - uid: 5272
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,9.5
       parent: 2
   - uid: 5273
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,9.5
       parent: 2
   - uid: 5274
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-2.5
       parent: 2
   - uid: 5281
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,4.5
       parent: 2
   - uid: 5290
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,16.5
       parent: 2
   - uid: 5295
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-3.5
       parent: 2
   - uid: 5304
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,4.5
       parent: 2
   - uid: 5318
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-0.5
       parent: 2
   - uid: 5319
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-1.5
       parent: 2
   - uid: 5320
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-2.5
       parent: 2
   - uid: 5321
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-3.5
       parent: 2
   - uid: 5322
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-4.5
       parent: 2
   - uid: 5323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,12.5
       parent: 2
   - uid: 5324
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,10.5
       parent: 2
   - uid: 5355
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,12.5
       parent: 2
   - uid: 5356
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,13.5
       parent: 2
   - uid: 5357
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,14.5
       parent: 2
   - uid: 5358
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,15.5
       parent: 2
   - uid: 5359
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,16.5
       parent: 2
   - uid: 5394
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,10.5
       parent: 2
   - uid: 5395
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-0.5
       parent: 2
   - uid: 5464
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,18.5
       parent: 2
   - uid: 15947
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,10.5
       parent: 2
@@ -91334,7379 +88878,5256 @@ entities:
   entities:
   - uid: 107
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,44.5
       parent: 2
   - uid: 110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,45.5
       parent: 2
   - uid: 160
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-1.5
       parent: 2
   - uid: 434
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-63.5
       parent: 2
   - uid: 474
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
   - uid: 476
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-0.5
       parent: 2
   - uid: 477
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-0.5
       parent: 2
   - uid: 479
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,0.5
       parent: 2
   - uid: 480
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,2.5
       parent: 2
   - uid: 481
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,3.5
       parent: 2
   - uid: 482
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,4.5
       parent: 2
   - uid: 484
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,4.5
       parent: 2
   - uid: 485
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,4.5
       parent: 2
   - uid: 487
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,5.5
       parent: 2
   - uid: 488
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,7.5
       parent: 2
   - uid: 489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,4.5
       parent: 2
   - uid: 490
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,3.5
       parent: 2
   - uid: 491
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,7.5
       parent: 2
   - uid: 492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,0.5
       parent: 2
   - uid: 493
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,2.5
       parent: 2
   - uid: 496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,6.5
       parent: 2
   - uid: 497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,7.5
       parent: 2
   - uid: 498
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,4.5
       parent: 2
   - uid: 499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,4.5
       parent: 2
   - uid: 500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,4.5
       parent: 2
   - uid: 501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,5.5
       parent: 2
   - uid: 502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,6.5
       parent: 2
   - uid: 503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,4.5
       parent: 2
   - uid: 504
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,7.5
       parent: 2
   - uid: 531
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-1.5
       parent: 2
   - uid: 539
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-48.5
       parent: 2
   - uid: 585
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,4.5
       parent: 2
   - uid: 586
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,3.5
       parent: 2
   - uid: 587
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,2.5
       parent: 2
   - uid: 588
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-1.5
       parent: 2
   - uid: 603
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,0.5
       parent: 2
   - uid: 604
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-0.5
       parent: 2
   - uid: 629
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-48.5
       parent: 2
   - uid: 885
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,6.5
       parent: 2
   - uid: 890
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-11.5
       parent: 2
   - uid: 1075
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,-4.5
       parent: 2
   - uid: 1076
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-4.5
       parent: 2
   - uid: 1077
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
   - uid: 1078
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,-10.5
       parent: 2
   - uid: 1079
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-10.5
       parent: 2
   - uid: 1080
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-10.5
       parent: 2
   - uid: 1081
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-9.5
       parent: 2
   - uid: 1082
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-7.5
       parent: 2
   - uid: 1083
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-6.5
       parent: 2
   - uid: 1084
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-5.5
       parent: 2
   - uid: 1085
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-5.5
       parent: 2
   - uid: 1086
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-8.5
       parent: 2
   - uid: 1226
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,9.5
       parent: 2
   - uid: 1246
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,8.5
       parent: 2
   - uid: 1248
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,9.5
       parent: 2
   - uid: 1249
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,9.5
       parent: 2
   - uid: 1255
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,6.5
       parent: 2
   - uid: 1256
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,9.5
       parent: 2
   - uid: 1292
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,42.5
       parent: 2
   - uid: 1304
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-20.5
       parent: 2
   - uid: 1305
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-20.5
       parent: 2
   - uid: 1306
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-20.5
       parent: 2
   - uid: 1307
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-20.5
       parent: 2
   - uid: 1308
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-20.5
       parent: 2
   - uid: 1309
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-19.5
       parent: 2
   - uid: 1310
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-19.5
       parent: 2
   - uid: 1311
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-20.5
       parent: 2
   - uid: 1315
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-20.5
       parent: 2
   - uid: 1317
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-19.5
       parent: 2
   - uid: 1320
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-16.5
       parent: 2
   - uid: 1321
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-15.5
       parent: 2
   - uid: 1326
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-16.5
       parent: 2
   - uid: 1328
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-15.5
       parent: 2
   - uid: 1330
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-16.5
       parent: 2
   - uid: 1332
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-18.5
       parent: 2
   - uid: 1333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-17.5
       parent: 2
   - uid: 1334
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-18.5
       parent: 2
   - uid: 1341
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-15.5
       parent: 2
   - uid: 1342
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-15.5
       parent: 2
   - uid: 1371
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,-23.5
       parent: 2
   - uid: 1373
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
   - uid: 1385
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-11.5
       parent: 2
   - uid: 1390
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-8.5
       parent: 2
   - uid: 1391
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-8.5
       parent: 2
   - uid: 1393
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-8.5
       parent: 2
   - uid: 1394
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-8.5
       parent: 2
   - uid: 1398
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-27.5
       parent: 2
   - uid: 1402
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-15.5
       parent: 2
   - uid: 1403
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-14.5
       parent: 2
   - uid: 1404
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-14.5
       parent: 2
   - uid: 1405
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-15.5
       parent: 2
   - uid: 1406
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-13.5
       parent: 2
   - uid: 1407
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-14.5
       parent: 2
   - uid: 1408
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-13.5
       parent: 2
   - uid: 1409
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-14.5
       parent: 2
   - uid: 1410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,-13.5
       parent: 2
   - uid: 1411
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,-14.5
       parent: 2
   - uid: 1412
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,-13.5
       parent: 2
   - uid: 1413
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,-14.5
       parent: 2
   - uid: 1414
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-13.5
       parent: 2
   - uid: 1415
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-14.5
       parent: 2
   - uid: 1416
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-13.5
       parent: 2
   - uid: 1417
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-14.5
       parent: 2
   - uid: 1418
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-15.5
       parent: 2
   - uid: 1419
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-16.5
       parent: 2
   - uid: 1420
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-17.5
       parent: 2
   - uid: 1421
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-18.5
       parent: 2
   - uid: 1422
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-19.5
       parent: 2
   - uid: 1423
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-20.5
       parent: 2
   - uid: 1425
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-15.5
       parent: 2
   - uid: 1426
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-16.5
       parent: 2
   - uid: 1427
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-17.5
       parent: 2
   - uid: 1428
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-18.5
       parent: 2
   - uid: 1429
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-19.5
       parent: 2
   - uid: 1430
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-20.5
       parent: 2
   - uid: 1431
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-21.5
       parent: 2
   - uid: 1432
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-20.5
       parent: 2
   - uid: 1433
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,-20.5
       parent: 2
   - uid: 1434
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-18.5
       parent: 2
   - uid: 1435
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-20.5
       parent: 2
   - uid: 1436
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-19.5
       parent: 2
   - uid: 1437
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-20.5
       parent: 2
   - uid: 1438
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-21.5
       parent: 2
   - uid: 1439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-18.5
       parent: 2
   - uid: 1440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-19.5
       parent: 2
   - uid: 1441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-20.5
       parent: 2
   - uid: 1444
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-22.5
       parent: 2
   - uid: 1445
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-23.5
       parent: 2
   - uid: 1446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-24.5
       parent: 2
   - uid: 1447
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-25.5
       parent: 2
   - uid: 1448
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-21.5
       parent: 2
   - uid: 1449
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-22.5
       parent: 2
   - uid: 1450
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-23.5
       parent: 2
   - uid: 1451
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-24.5
       parent: 2
   - uid: 1452
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-25.5
       parent: 2
   - uid: 1453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-26.5
       parent: 2
   - uid: 1454
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-24.5
       parent: 2
   - uid: 1455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-22.5
       parent: 2
   - uid: 1458
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-25.5
       parent: 2
   - uid: 1459
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-26.5
       parent: 2
   - uid: 1463
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-23.5
       parent: 2
   - uid: 1474
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-24.5
       parent: 2
   - uid: 1476
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,-25.5
       parent: 2
   - uid: 1492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,26.5
       parent: 2
   - uid: 1493
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-25.5
       parent: 2
   - uid: 1494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,-26.5
       parent: 2
   - uid: 1495
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-26.5
       parent: 2
   - uid: 1496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-27.5
       parent: 2
   - uid: 1497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-28.5
       parent: 2
   - uid: 1498
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-28.5
       parent: 2
   - uid: 1500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-25.5
       parent: 2
   - uid: 1501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-25.5
       parent: 2
   - uid: 1502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-26.5
       parent: 2
   - uid: 1503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-27.5
       parent: 2
   - uid: 1504
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-28.5
       parent: 2
   - uid: 1505
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-28.5
       parent: 2
   - uid: 1534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-27.5
       parent: 2
   - uid: 1539
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-10.5
       parent: 2
   - uid: 1542
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-8.5
       parent: 2
   - uid: 1543
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-8.5
       parent: 2
   - uid: 1544
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-9.5
       parent: 2
   - uid: 1545
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-10.5
       parent: 2
   - uid: 1547
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,-10.5
       parent: 2
   - uid: 1548
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,-10.5
       parent: 2
   - uid: 1549
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-11.5
       parent: 2
   - uid: 1550
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,-11.5
       parent: 2
   - uid: 1552
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-11.5
       parent: 2
   - uid: 1553
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-10.5
       parent: 2
   - uid: 1554
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-9.5
       parent: 2
   - uid: 1556
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-8.5
       parent: 2
   - uid: 1557
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-8.5
       parent: 2
   - uid: 1558
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,-8.5
       parent: 2
   - uid: 1559
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-8.5
       parent: 2
   - uid: 1564
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-2.5
       parent: 2
   - uid: 1569
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-2.5
       parent: 2
   - uid: 1571
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-5.5
       parent: 2
   - uid: 1572
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-5.5
       parent: 2
   - uid: 1573
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,-5.5
       parent: 2
   - uid: 1574
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-5.5
       parent: 2
   - uid: 1575
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-5.5
       parent: 2
   - uid: 1576
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-5.5
       parent: 2
   - uid: 1577
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-5.5
       parent: 2
   - uid: 1578
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-5.5
       parent: 2
   - uid: 1579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-2.5
       parent: 2
   - uid: 1580
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-2.5
       parent: 2
   - uid: 1581
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-2.5
       parent: 2
   - uid: 1582
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-2.5
       parent: 2
   - uid: 1583
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,-2.5
       parent: 2
   - uid: 1584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-2.5
       parent: 2
   - uid: 1585
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-1.5
       parent: 2
   - uid: 1586
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-1.5
       parent: 2
   - uid: 1616
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,-0.5
       parent: 2
   - uid: 1617
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,0.5
       parent: 2
   - uid: 1619
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,-0.5
       parent: 2
   - uid: 1621
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,0.5
       parent: 2
   - uid: 1622
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,1.5
       parent: 2
   - uid: 1624
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,1.5
       parent: 2
   - uid: 1625
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,1.5
       parent: 2
   - uid: 1626
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,1.5
       parent: 2
   - uid: 1628
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-0.5
       parent: 2
   - uid: 1629
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-0.5
       parent: 2
   - uid: 1649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,38.5
       parent: 2
   - uid: 1654
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,1.5
       parent: 2
   - uid: 1698
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,43.5
       parent: 2
   - uid: 1716
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,39.5
       parent: 2
   - uid: 1737
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-27.5
       parent: 2
   - uid: 1743
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-26.5
       parent: 2
   - uid: 1744
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,-27.5
       parent: 2
   - uid: 1749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-22.5
       parent: 2
   - uid: 1753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,-25.5
       parent: 2
   - uid: 1754
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-25.5
       parent: 2
   - uid: 1758
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-22.5
       parent: 2
   - uid: 1794
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,-22.5
       parent: 2
   - uid: 1865
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,6.5
       parent: 2
   - uid: 1879
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-21.5
       parent: 2
   - uid: 1882
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-13.5
       parent: 2
   - uid: 1982
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-41.5
       parent: 2
   - uid: 1996
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-60.5
       parent: 2
   - uid: 2008
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-41.5
       parent: 2
   - uid: 2015
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-42.5
       parent: 2
   - uid: 2027
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-38.5
       parent: 2
   - uid: 2051
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-38.5
       parent: 2
   - uid: 2101
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,6.5
       parent: 2
   - uid: 2102
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,7.5
       parent: 2
   - uid: 2118
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,6.5
       parent: 2
   - uid: 2334
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,26.5
       parent: 2
   - uid: 2338
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,-27.5
       parent: 2
   - uid: 2377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-27.5
       parent: 2
   - uid: 2378
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,7.5
       parent: 2
   - uid: 2383
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,8.5
       parent: 2
   - uid: 2424
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-44.5
       parent: 2
   - uid: 2425
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-42.5
       parent: 2
   - uid: 2426
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-50.5
       parent: 2
   - uid: 2427
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-52.5
       parent: 2
   - uid: 2432
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-50.5
       parent: 2
   - uid: 2434
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-47.5
       parent: 2
   - uid: 2435
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-42.5
       parent: 2
   - uid: 2436
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-40.5
       parent: 2
   - uid: 2437
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-39.5
       parent: 2
   - uid: 2438
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-39.5
       parent: 2
   - uid: 2439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-39.5
       parent: 2
   - uid: 2440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-39.5
       parent: 2
   - uid: 2441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-39.5
       parent: 2
   - uid: 2442
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-39.5
       parent: 2
   - uid: 2443
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-39.5
       parent: 2
   - uid: 2444
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-39.5
       parent: 2
   - uid: 2445
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-40.5
       parent: 2
   - uid: 2452
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-61.5
       parent: 2
   - uid: 2464
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-43.5
       parent: 2
   - uid: 2480
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-38.5
       parent: 2
   - uid: 2481
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-38.5
       parent: 2
   - uid: 2482
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-32.5
       parent: 2
   - uid: 2483
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-31.5
       parent: 2
   - uid: 2484
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-31.5
       parent: 2
   - uid: 2487
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-31.5
       parent: 2
   - uid: 2488
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-31.5
       parent: 2
   - uid: 2489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-32.5
       parent: 2
   - uid: 2490
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-33.5
       parent: 2
   - uid: 2491
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-33.5
       parent: 2
   - uid: 2559
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-44.5
       parent: 2
   - uid: 2775
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-38.5
       parent: 2
   - uid: 2784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-42.5
       parent: 2
   - uid: 2793
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-40.5
       parent: 2
   - uid: 2795
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-39.5
       parent: 2
   - uid: 2805
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-43.5
       parent: 2
   - uid: 2806
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-44.5
       parent: 2
   - uid: 2807
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-44.5
       parent: 2
   - uid: 2808
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-44.5
       parent: 2
   - uid: 2809
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-44.5
       parent: 2
   - uid: 2810
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-43.5
       parent: 2
   - uid: 2811
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-42.5
       parent: 2
   - uid: 2812
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-41.5
       parent: 2
   - uid: 2819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-38.5
       parent: 2
   - uid: 2820
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-42.5
       parent: 2
   - uid: 2829
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-41.5
       parent: 2
   - uid: 2831
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-41.5
       parent: 2
   - uid: 2871
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-39.5
       parent: 2
   - uid: 3024
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-17.5
       parent: 2
   - uid: 3185
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,39.5
       parent: 2
   - uid: 3278
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,39.5
       parent: 2
   - uid: 3280
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,41.5
       parent: 2
   - uid: 3281
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,38.5
       parent: 2
   - uid: 3283
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,40.5
       parent: 2
   - uid: 3285
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,41.5
       parent: 2
   - uid: 3300
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,41.5
       parent: 2
   - uid: 3313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,43.5
       parent: 2
   - uid: 3410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-16.5
       parent: 2
   - uid: 3431
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-63.5
       parent: 2
   - uid: 3436
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-64.5
       parent: 2
   - uid: 3439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-65.5
       parent: 2
   - uid: 3445
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-65.5
       parent: 2
   - uid: 3448
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-66.5
       parent: 2
   - uid: 3451
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-66.5
       parent: 2
   - uid: 3467
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-65.5
       parent: 2
   - uid: 3471
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-65.5
       parent: 2
   - uid: 3478
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-64.5
       parent: 2
   - uid: 3485
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,32.5
       parent: 2
   - uid: 3486
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-64.5
       parent: 2
   - uid: 3490
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-63.5
       parent: 2
   - uid: 3496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-63.5
       parent: 2
   - uid: 3505
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-63.5
       parent: 2
   - uid: 3517
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-62.5
       parent: 2
   - uid: 3530
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-43.5
       parent: 2
   - uid: 3542
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,38.5
       parent: 2
   - uid: 3547
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,5.5
       parent: 2
   - uid: 3570
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,40.5
       parent: 2
   - uid: 3581
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,5.5
       parent: 2
   - uid: 3614
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-42.5
       parent: 2
   - uid: 3616
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-56.5
       parent: 2
   - uid: 3617
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-57.5
       parent: 2
   - uid: 3623
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-60.5
       parent: 2
   - uid: 3630
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-61.5
       parent: 2
   - uid: 3631
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-62.5
       parent: 2
   - uid: 3632
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-41.5
       parent: 2
   - uid: 3633
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-40.5
       parent: 2
   - uid: 3635
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-38.5
       parent: 2
   - uid: 3636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,43.5
       parent: 2
   - uid: 3638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,43.5
       parent: 2
   - uid: 3654
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,46.5
       parent: 2
   - uid: 3658
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-45.5
       parent: 2
   - uid: 3676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-52.5
       parent: 2
   - uid: 3677
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-51.5
       parent: 2
   - uid: 3686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-50.5
       parent: 2
   - uid: 3687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-49.5
       parent: 2
   - uid: 3688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-47.5
       parent: 2
   - uid: 3689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-48.5
       parent: 2
   - uid: 3690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-49.5
       parent: 2
   - uid: 3692
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-46.5
       parent: 2
   - uid: 3693
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-47.5
       parent: 2
   - uid: 3699
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-46.5
       parent: 2
   - uid: 3703
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-53.5
       parent: 2
   - uid: 3705
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-54.5
       parent: 2
   - uid: 3706
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-55.5
       parent: 2
   - uid: 3707
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-56.5
       parent: 2
   - uid: 3708
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-57.5
       parent: 2
   - uid: 3709
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-57.5
       parent: 2
   - uid: 3712
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-58.5
       parent: 2
   - uid: 3744
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-59.5
       parent: 2
   - uid: 3745
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-31.5
       parent: 2
   - uid: 3746
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-33.5
       parent: 2
   - uid: 3747
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-60.5
       parent: 2
   - uid: 3748
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-61.5
       parent: 2
   - uid: 3749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-61.5
       parent: 2
   - uid: 3751
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-62.5
       parent: 2
   - uid: 3752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-63.5
       parent: 2
   - uid: 3755
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-63.5
       parent: 2
   - uid: 3759
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-63.5
       parent: 2
   - uid: 3760
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-63.5
       parent: 2
   - uid: 3776
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-64.5
       parent: 2
   - uid: 3779
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-64.5
       parent: 2
   - uid: 3783
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-65.5
       parent: 2
   - uid: 3785
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-65.5
       parent: 2
   - uid: 3786
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-65.5
       parent: 2
   - uid: 3787
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-66.5
       parent: 2
   - uid: 3926
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-66.5
       parent: 2
   - uid: 3955
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-66.5
       parent: 2
   - uid: 3956
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-65.5
       parent: 2
   - uid: 4008
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-64.5
       parent: 2
   - uid: 4037
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-63.5
       parent: 2
   - uid: 4038
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-28.5
       parent: 2
   - uid: 4049
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-46.5
       parent: 2
   - uid: 4147
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-45.5
       parent: 2
   - uid: 4153
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-45.5
       parent: 2
   - uid: 4154
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-48.5
       parent: 2
   - uid: 4157
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-50.5
       parent: 2
   - uid: 4186
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-44.5
       parent: 2
   - uid: 4187
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-43.5
       parent: 2
   - uid: 4188
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-50.5
       parent: 2
   - uid: 4189
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-48.5
       parent: 2
   - uid: 4190
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-47.5
       parent: 2
   - uid: 4191
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-47.5
       parent: 2
   - uid: 4192
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-47.5
       parent: 2
   - uid: 4193
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-51.5
       parent: 2
   - uid: 4194
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-51.5
       parent: 2
   - uid: 4195
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-51.5
       parent: 2
   - uid: 4196
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-51.5
       parent: 2
   - uid: 4197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-50.5
       parent: 2
   - uid: 4198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-48.5
       parent: 2
   - uid: 4199
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-47.5
       parent: 2
   - uid: 4218
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-42.5
       parent: 2
   - uid: 4219
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-42.5
       parent: 2
   - uid: 4220
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-42.5
       parent: 2
   - uid: 4221
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-42.5
       parent: 2
   - uid: 4222
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-43.5
       parent: 2
   - uid: 4223
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-44.5
       parent: 2
   - uid: 4224
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-45.5
       parent: 2
   - uid: 4225
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-45.5
       parent: 2
   - uid: 4248
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-44.5
       parent: 2
   - uid: 4249
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-43.5
       parent: 2
   - uid: 4420
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-52.5
       parent: 2
   - uid: 4439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-52.5
       parent: 2
   - uid: 4455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-53.5
       parent: 2
   - uid: 4462
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-52.5
       parent: 2
   - uid: 4463
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-53.5
       parent: 2
   - uid: 4464
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-54.5
       parent: 2
   - uid: 4467
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-54.5
       parent: 2
   - uid: 4468
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-55.5
       parent: 2
   - uid: 4497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-55.5
       parent: 2
   - uid: 4501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,3.5
       parent: 2
   - uid: 4566
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-58.5
       parent: 2
   - uid: 4567
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-56.5
       parent: 2
   - uid: 4569
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-59.5
       parent: 2
   - uid: 4570
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-60.5
       parent: 2
   - uid: 4584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-61.5
       parent: 2
   - uid: 4586
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-61.5
       parent: 2
   - uid: 4587
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-62.5
       parent: 2
   - uid: 4596
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-39.5
       parent: 2
   - uid: 4597
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-38.5
       parent: 2
   - uid: 4599
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-37.5
       parent: 2
   - uid: 4608
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-36.5
       parent: 2
   - uid: 4609
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-35.5
       parent: 2
   - uid: 4610
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-35.5
       parent: 2
   - uid: 4660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,3.5
       parent: 2
   - uid: 4662
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,4.5
       parent: 2
   - uid: 4667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,9.5
       parent: 2
   - uid: 4687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,10.5
       parent: 2
   - uid: 4706
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-35.5
       parent: 2
   - uid: 4707
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-35.5
       parent: 2
   - uid: 4709
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-35.5
       parent: 2
   - uid: 4710
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-34.5
       parent: 2
   - uid: 4711
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-29.5
       parent: 2
   - uid: 4737
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-2.5
       parent: 2
   - uid: 4738
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-2.5
       parent: 2
   - uid: 4739
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-2.5
       parent: 2
   - uid: 4741
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-1.5
       parent: 2
   - uid: 4742
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-2.5
       parent: 2
   - uid: 4743
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-0.5
       parent: 2
   - uid: 4745
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,0.5
       parent: 2
   - uid: 4746
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,0.5
       parent: 2
   - uid: 4749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-1.5
       parent: 2
   - uid: 4750
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,0.5
       parent: 2
   - uid: 4768
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,9.5
       parent: 2
   - uid: 4772
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,10.5
       parent: 2
   - uid: 4773
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,4.5
       parent: 2
   - uid: 4798
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,46.5
       parent: 2
   - uid: 4800
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,43.5
       parent: 2
   - uid: 4811
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,0.5
       parent: 2
   - uid: 4841
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,43.5
       parent: 2
   - uid: 4842
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-30.5
       parent: 2
   - uid: 4847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,-27.5
       parent: 2
   - uid: 4848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-26.5
       parent: 2
   - uid: 4849
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-29.5
       parent: 2
   - uid: 4857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-29.5
       parent: 2
   - uid: 4875
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-30.5
       parent: 2
   - uid: 5060
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-15.5
       parent: 2
   - uid: 5367
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-30.5
       parent: 2
   - uid: 6310
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,31.5
       parent: 2
   - uid: 6311
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,33.5
       parent: 2
   - uid: 6323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,46.5
       parent: 2
   - uid: 6324
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,44.5
       parent: 2
   - uid: 6325
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-30.5
       parent: 2
   - uid: 6327
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,44.5
       parent: 2
   - uid: 6329
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,44.5
       parent: 2
   - uid: 6330
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,44.5
       parent: 2
   - uid: 6333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,45.5
       parent: 2
   - uid: 6336
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,47.5
       parent: 2
   - uid: 6403
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,48.5
       parent: 2
   - uid: 6424
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,44.5
       parent: 2
   - uid: 6425
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,44.5
       parent: 2
   - uid: 6426
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,44.5
       parent: 2
   - uid: 6434
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,48.5
       parent: 2
   - uid: 6435
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,48.5
       parent: 2
   - uid: 6436
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,47.5
       parent: 2
   - uid: 6444
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,45.5
       parent: 2
   - uid: 6445
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,44.5
       parent: 2
   - uid: 6446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,44.5
       parent: 2
   - uid: 6462
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,44.5
       parent: 2
   - uid: 6463
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,44.5
       parent: 2
   - uid: 6473
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-30.5
       parent: 2
   - uid: 6475
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,46.5
       parent: 2
   - uid: 6495
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,48.5
       parent: 2
   - uid: 6500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,48.5
       parent: 2
   - uid: 6525
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-41.5
       parent: 2
   - uid: 6533
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-40.5
       parent: 2
   - uid: 6541
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-29.5
       parent: 2
   - uid: 6546
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-30.5
       parent: 2
   - uid: 6550
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-30.5
       parent: 2
   - uid: 6551
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-31.5
       parent: 2
   - uid: 6553
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-30.5
       parent: 2
   - uid: 6557
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-31.5
       parent: 2
   - uid: 6558
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-30.5
       parent: 2
   - uid: 6560
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-31.5
       parent: 2
   - uid: 6561
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-31.5
       parent: 2
   - uid: 6564
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-32.5
       parent: 2
   - uid: 6580
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-32.5
       parent: 2
   - uid: 6584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-38.5
       parent: 2
   - uid: 6586
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-38.5
       parent: 2
   - uid: 6587
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-37.5
       parent: 2
   - uid: 6589
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-35.5
       parent: 2
   - uid: 6591
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-35.5
       parent: 2
   - uid: 6623
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-34.5
       parent: 2
   - uid: 6628
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-33.5
       parent: 2
   - uid: 6630
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-33.5
       parent: 2
   - uid: 6632
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-34.5
       parent: 2
   - uid: 6636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-39.5
       parent: 2
   - uid: 6640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-39.5
       parent: 2
   - uid: 6646
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-40.5
       parent: 2
   - uid: 6647
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-45.5
       parent: 2
   - uid: 6648
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-27.5
       parent: 2
   - uid: 6649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-28.5
       parent: 2
   - uid: 6652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-19.5
       parent: 2
   - uid: 6654
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-18.5
       parent: 2
   - uid: 6655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,-17.5
       parent: 2
   - uid: 6659
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,-16.5
       parent: 2
   - uid: 6697
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-27.5
       parent: 2
   - uid: 6854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-28.5
       parent: 2
   - uid: 6879
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,40.5
       parent: 2
   - uid: 6887
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,40.5
       parent: 2
   - uid: 6916
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,41.5
       parent: 2
   - uid: 6917
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,43.5
       parent: 2
   - uid: 6925
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,42.5
       parent: 2
   - uid: 6926
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,45.5
       parent: 2
   - uid: 6936
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-29.5
       parent: 2
   - uid: 6945
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-29.5
       parent: 2
   - uid: 6975
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,40.5
       parent: 2
   - uid: 6976
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,43.5
       parent: 2
   - uid: 6977
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,43.5
       parent: 2
   - uid: 6987
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,40.5
       parent: 2
   - uid: 6992
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,43.5
       parent: 2
   - uid: 6996
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,47.5
       parent: 2
   - uid: 7000
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,41.5
       parent: 2
   - uid: 7004
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,45.5
       parent: 2
   - uid: 7033
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-29.5
       parent: 2
   - uid: 7035
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-29.5
       parent: 2
   - uid: 7053
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-28.5
       parent: 2
   - uid: 7067
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-28.5
       parent: 2
   - uid: 7069
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-28.5
       parent: 2
   - uid: 7075
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-28.5
       parent: 2
   - uid: 7076
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-27.5
       parent: 2
   - uid: 7077
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-27.5
       parent: 2
   - uid: 7088
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-26.5
       parent: 2
   - uid: 7091
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-26.5
       parent: 2
   - uid: 7093
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,42.5
       parent: 2
   - uid: 7095
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,45.5
       parent: 2
   - uid: 7096
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,45.5
       parent: 2
   - uid: 7107
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-29.5
       parent: 2
   - uid: 7118
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-29.5
       parent: 2
   - uid: 7120
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-30.5
       parent: 2
   - uid: 7130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-13.5
       parent: 2
   - uid: 7132
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-13.5
       parent: 2
   - uid: 7143
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-24.5
       parent: 2
   - uid: 7145
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-20.5
       parent: 2
   - uid: 7147
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-26.5
       parent: 2
   - uid: 7153
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-25.5
       parent: 2
   - uid: 7155
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-22.5
       parent: 2
   - uid: 7211
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,48.5
       parent: 2
   - uid: 7213
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,49.5
       parent: 2
   - uid: 7214
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,49.5
       parent: 2
   - uid: 7216
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,48.5
       parent: 2
   - uid: 7217
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,47.5
       parent: 2
   - uid: 7218
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,46.5
       parent: 2
   - uid: 7219
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,45.5
       parent: 2
   - uid: 7220
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,45.5
       parent: 2
   - uid: 7221
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,50.5
       parent: 2
   - uid: 7223
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,50.5
       parent: 2
   - uid: 7317
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-12.5
       parent: 2
   - uid: 7318
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-21.5
       parent: 2
   - uid: 7598
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-23.5
       parent: 2
   - uid: 7663
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,48.5
       parent: 2
   - uid: 7664
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,48.5
       parent: 2
   - uid: 7667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,48.5
       parent: 2
   - uid: 7668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,48.5
       parent: 2
   - uid: 7669
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,47.5
       parent: 2
   - uid: 7670
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,46.5
       parent: 2
   - uid: 7671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,45.5
       parent: 2
   - uid: 7672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,44.5
       parent: 2
   - uid: 7673
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,44.5
       parent: 2
   - uid: 7674
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,44.5
       parent: 2
   - uid: 7675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,44.5
       parent: 2
   - uid: 7676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,44.5
       parent: 2
   - uid: 7677
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,54.5
       parent: 2
   - uid: 7678
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,54.5
       parent: 2
   - uid: 7679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,53.5
       parent: 2
   - uid: 7680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,53.5
       parent: 2
   - uid: 7681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,52.5
       parent: 2
   - uid: 7682
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,52.5
       parent: 2
   - uid: 7683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,51.5
       parent: 2
   - uid: 7684
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,50.5
       parent: 2
   - uid: 7685
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,49.5
       parent: 2
   - uid: 7686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,54.5
       parent: 2
   - uid: 7687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,54.5
       parent: 2
   - uid: 7688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,53.5
       parent: 2
   - uid: 7689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,53.5
       parent: 2
   - uid: 7690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,52.5
       parent: 2
   - uid: 7691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,52.5
       parent: 2
   - uid: 7692
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,51.5
       parent: 2
   - uid: 7693
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,50.5
       parent: 2
   - uid: 7694
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,49.5
       parent: 2
   - uid: 8012
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-12.5
       parent: 2
   - uid: 8458
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-11.5
       parent: 2
   - uid: 8694
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,30.5
       parent: 2
   - uid: 8723
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-64.5
       parent: 2
   - uid: 8758
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-63.5
       parent: 2
   - uid: 8903
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,34.5
       parent: 2
   - uid: 8995
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,30.5
       parent: 2
   - uid: 8996
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,30.5
       parent: 2
   - uid: 9008
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,31.5
       parent: 2
   - uid: 9256
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,1.5
       parent: 2
   - uid: 9303
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,33.5
       parent: 2
   - uid: 9305
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,34.5
       parent: 2
   - uid: 9306
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,33.5
       parent: 2
   - uid: 9309
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,33.5
       parent: 2
   - uid: 9310
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,33.5
       parent: 2
   - uid: 9387
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,34.5
       parent: 2
   - uid: 9393
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-11.5
       parent: 2
   - uid: 9397
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-10.5
       parent: 2
   - uid: 9403
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-9.5
       parent: 2
   - uid: 9424
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-9.5
       parent: 2
   - uid: 9437
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-8.5
       parent: 2
   - uid: 9458
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-8.5
       parent: 2
   - uid: 9484
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-7.5
       parent: 2
   - uid: 9518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,45.5
       parent: 2
   - uid: 9526
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-6.5
       parent: 2
   - uid: 9574
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,45.5
       parent: 2
   - uid: 9576
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,45.5
       parent: 2
   - uid: 9666
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,30.5
       parent: 2
   - uid: 9729
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,45.5
       parent: 2
   - uid: 9828
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-61.5
       parent: 2
   - uid: 9927
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,34.5
       parent: 2
   - uid: 9939
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,31.5
       parent: 2
   - uid: 10225
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-5.5
       parent: 2
   - uid: 10226
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-4.5
       parent: 2
   - uid: 10265
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,36.5
       parent: 2
   - uid: 10266
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,26.5
       parent: 2
   - uid: 10267
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,25.5
       parent: 2
   - uid: 10268
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,24.5
       parent: 2
   - uid: 10269
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,23.5
       parent: 2
   - uid: 10270
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,23.5
       parent: 2
   - uid: 10271
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,23.5
       parent: 2
   - uid: 10272
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,23.5
       parent: 2
   - uid: 10273
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,24.5
       parent: 2
   - uid: 10274
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,26.5
       parent: 2
   - uid: 10282
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-60.5
       parent: 2
   - uid: 10371
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,43.5
       parent: 2
   - uid: 10377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-7.5
       parent: 2
   - uid: 10387
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-7.5
       parent: 2
   - uid: 10388
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-3.5
       parent: 2
   - uid: 10404
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-0.5
       parent: 2
   - uid: 10457
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,0.5
       parent: 2
   - uid: 10458
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,1.5
       parent: 2
   - uid: 10471
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,1.5
       parent: 2
   - uid: 10489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,2.5
       parent: 2
   - uid: 10491
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,2.5
       parent: 2
   - uid: 10497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,2.5
       parent: 2
   - uid: 10499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,2.5
       parent: 2
   - uid: 10502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,2.5
       parent: 2
   - uid: 10506
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,3.5
       parent: 2
   - uid: 10510
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,37.5
       parent: 2
   - uid: 10511
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,3.5
       parent: 2
   - uid: 10514
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,3.5
       parent: 2
   - uid: 10518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,38.5
       parent: 2
   - uid: 10533
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,44.5
       parent: 2
   - uid: 10536
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,47.5
       parent: 2
   - uid: 10540
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,47.5
       parent: 2
   - uid: 10541
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,47.5
       parent: 2
   - uid: 10542
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,46.5
       parent: 2
   - uid: 10544
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,47.5
       parent: 2
   - uid: 10546
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,46.5
       parent: 2
   - uid: 10552
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,45.5
       parent: 2
   - uid: 10553
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,44.5
       parent: 2
   - uid: 10558
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,44.5
       parent: 2
   - uid: 10559
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,43.5
       parent: 2
   - uid: 10560
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,42.5
       parent: 2
   - uid: 10561
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,41.5
       parent: 2
   - uid: 10562
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,41.5
       parent: 2
   - uid: 10563
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,40.5
       parent: 2
   - uid: 10572
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,39.5
       parent: 2
   - uid: 10573
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,38.5
       parent: 2
   - uid: 10575
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,38.5
       parent: 2
   - uid: 10576
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,37.5
       parent: 2
   - uid: 10577
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,36.5
       parent: 2
   - uid: 10579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,35.5
       parent: 2
   - uid: 10581
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,35.5
       parent: 2
   - uid: 10583
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,35.5
       parent: 2
   - uid: 10585
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,35.5
       parent: 2
   - uid: 10587
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,34.5
       parent: 2
   - uid: 10588
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,30.5
       parent: 2
   - uid: 10590
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,29.5
       parent: 2
   - uid: 10592
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,28.5
       parent: 2
   - uid: 10607
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,28.5
       parent: 2
   - uid: 10608
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,28.5
       parent: 2
   - uid: 10609
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,28.5
       parent: 2
   - uid: 10610
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,27.5
       parent: 2
   - uid: 10611
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,29.5
       parent: 2
   - uid: 10620
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,29.5
       parent: 2
   - uid: 10621
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,29.5
       parent: 2
   - uid: 10622
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,27.5
       parent: 2
   - uid: 10625
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,26.5
       parent: 2
   - uid: 10629
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,26.5
       parent: 2
   - uid: 10630
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,25.5
       parent: 2
   - uid: 10631
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,25.5
       parent: 2
   - uid: 10632
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,25.5
       parent: 2
   - uid: 10633
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,22.5
       parent: 2
   - uid: 10634
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,21.5
       parent: 2
   - uid: 10638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,21.5
       parent: 2
   - uid: 10639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,20.5
       parent: 2
   - uid: 10640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,20.5
       parent: 2
   - uid: 10644
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,19.5
       parent: 2
   - uid: 10645
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,18.5
       parent: 2
   - uid: 10646
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,16.5
       parent: 2
   - uid: 10647
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,15.5
       parent: 2
   - uid: 10648
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,14.5
       parent: 2
   - uid: 10654
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,14.5
       parent: 2
   - uid: 10660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,13.5
       parent: 2
   - uid: 10664
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,13.5
       parent: 2
   - uid: 10665
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,13.5
       parent: 2
   - uid: 10666
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,12.5
       parent: 2
   - uid: 10667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,12.5
       parent: 2
   - uid: 10668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,11.5
       parent: 2
   - uid: 10669
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,11.5
       parent: 2
   - uid: 10670
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,10.5
       parent: 2
   - uid: 10671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,29.5
       parent: 2
   - uid: 10672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-9.5
       parent: 2
   - uid: 10677
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,-16.5
       parent: 2
   - uid: 10678
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,-15.5
       parent: 2
   - uid: 10680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,-15.5
       parent: 2
   - uid: 10682
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,-14.5
       parent: 2
   - uid: 10683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,-14.5
       parent: 2
   - uid: 10686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,-13.5
       parent: 2
   - uid: 10691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,-13.5
       parent: 2
   - uid: 10692
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,-12.5
       parent: 2
   - uid: 10694
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-12.5
       parent: 2
   - uid: 10695
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-11.5
       parent: 2
   - uid: 10697
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-10.5
       parent: 2
   - uid: 10698
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-8.5
       parent: 2
   - uid: 10700
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,-7.5
       parent: 2
   - uid: 10705
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,-6.5
       parent: 2
   - uid: 10706
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,-5.5
       parent: 2
   - uid: 10708
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,43.5
       parent: 2
   - uid: 10711
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,-4.5
       parent: 2
   - uid: 10713
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,1.5
       parent: 2
   - uid: 10714
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,2.5
       parent: 2
   - uid: 10716
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-3.5
       parent: 2
   - uid: 10719
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,3.5
       parent: 2
   - uid: 10723
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,0.5
       parent: 2
   - uid: 10724
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,0.5
       parent: 2
   - uid: 10725
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-3.5
       parent: 2
   - uid: 10726
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,4.5
       parent: 2
   - uid: 10727
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-2.5
       parent: 2
   - uid: 10729
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,5.5
       parent: 2
   - uid: 10731
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,0.5
       parent: 2
   - uid: 10732
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,6.5
       parent: 2
   - uid: 10742
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,11.5
       parent: 2
   - uid: 10744
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-64.5
       parent: 2
   - uid: 10747
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,12.5
       parent: 2
   - uid: 10754
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,13.5
       parent: 2
   - uid: 10756
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,16.5
       parent: 2
   - uid: 10760
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,16.5
       parent: 2
   - uid: 10761
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,16.5
       parent: 2
   - uid: 10762
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,16.5
       parent: 2
   - uid: 10790
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,34.5
       parent: 2
   - uid: 10805
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,16.5
       parent: 2
   - uid: 10830
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,14.5
       parent: 2
   - uid: 10839
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,15.5
       parent: 2
   - uid: 10959
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,17.5
       parent: 2
   - uid: 10960
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,18.5
       parent: 2
   - uid: 10961
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,19.5
       parent: 2
   - uid: 10962
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,20.5
       parent: 2
   - uid: 10963
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,21.5
       parent: 2
   - uid: 10964
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,22.5
       parent: 2
   - uid: 10965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,23.5
       parent: 2
   - uid: 10966
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,24.5
       parent: 2
   - uid: 10967
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,25.5
       parent: 2
   - uid: 10968
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,26.5
       parent: 2
   - uid: 10969
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,27.5
       parent: 2
   - uid: 10970
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,28.5
       parent: 2
   - uid: 10971
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,29.5
       parent: 2
   - uid: 10972
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,30.5
       parent: 2
   - uid: 10973
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,31.5
       parent: 2
   - uid: 10974
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,32.5
       parent: 2
   - uid: 10976
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,33.5
       parent: 2
   - uid: 10977
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,33.5
       parent: 2
   - uid: 10978
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,33.5
       parent: 2
   - uid: 10980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,33.5
       parent: 2
   - uid: 10981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,33.5
       parent: 2
   - uid: 10982
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,33.5
       parent: 2
   - uid: 10983
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,33.5
       parent: 2
   - uid: 10984
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,33.5
       parent: 2
   - uid: 10985
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,33.5
       parent: 2
   - uid: 10986
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,33.5
       parent: 2
   - uid: 10987
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,33.5
       parent: 2
   - uid: 10988
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,33.5
       parent: 2
   - uid: 10989
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,33.5
       parent: 2
   - uid: 10990
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,33.5
       parent: 2
   - uid: 10991
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,33.5
       parent: 2
   - uid: 10992
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,17.5
       parent: 2
   - uid: 10993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,17.5
       parent: 2
   - uid: 10994
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,17.5
       parent: 2
   - uid: 10995
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,17.5
       parent: 2
   - uid: 10996
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,17.5
       parent: 2
   - uid: 10997
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,17.5
       parent: 2
   - uid: 10998
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,17.5
       parent: 2
   - uid: 10999
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,17.5
       parent: 2
   - uid: 11000
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,17.5
       parent: 2
   - uid: 11001
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,17.5
       parent: 2
   - uid: 11002
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,17.5
       parent: 2
   - uid: 11003
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,17.5
       parent: 2
   - uid: 11004
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,17.5
       parent: 2
   - uid: 11005
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,17.5
       parent: 2
   - uid: 11006
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,17.5
       parent: 2
   - uid: 11007
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,17.5
       parent: 2
   - uid: 11072
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,34.5
       parent: 2
   - uid: 11093
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,34.5
       parent: 2
   - uid: 11094
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,34.5
       parent: 2
   - uid: 11095
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,33.5
       parent: 2
   - uid: 11096
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,31.5
       parent: 2
   - uid: 11097
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,29.5
       parent: 2
   - uid: 11098
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,27.5
       parent: 2
   - uid: 11099
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,25.5
       parent: 2
   - uid: 11100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,23.5
       parent: 2
   - uid: 11101
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,21.5
       parent: 2
   - uid: 11102
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,19.5
       parent: 2
   - uid: 11103
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,17.5
       parent: 2
   - uid: 11104
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,16.5
       parent: 2
   - uid: 11105
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,16.5
       parent: 2
   - uid: 11106
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,16.5
       parent: 2
   - uid: 11107
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,16.5
       parent: 2
   - uid: 11109
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,16.5
       parent: 2
   - uid: 11110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,17.5
       parent: 2
   - uid: 11112
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,18.5
       parent: 2
   - uid: 11114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,19.5
       parent: 2
   - uid: 11366
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-16.5
       parent: 2
   - uid: 11367
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-16.5
       parent: 2
   - uid: 11368
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-16.5
       parent: 2
   - uid: 11369
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-16.5
       parent: 2
   - uid: 11370
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-17.5
       parent: 2
   - uid: 11371
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-18.5
       parent: 2
   - uid: 11372
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-19.5
       parent: 2
   - uid: 11373
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-19.5
       parent: 2
   - uid: 11375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-19.5
       parent: 2
   - uid: 11377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-19.5
       parent: 2
   - uid: 11378
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-18.5
       parent: 2
   - uid: 11559
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,4.5
       parent: 2
   - uid: 11594
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,4.5
       parent: 2
   - uid: 11595
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,9.5
       parent: 2
   - uid: 11639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,9.5
       parent: 2
   - uid: 11641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,32.5
       parent: 2
   - uid: 11741
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,35.5
       parent: 2
   - uid: 11743
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,37.5
       parent: 2
   - uid: 11744
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,5.5
       parent: 2
   - uid: 11745
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,36.5
       parent: 2
   - uid: 11748
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,31.5
       parent: 2
   - uid: 11751
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,31.5
       parent: 2
   - uid: 11754
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,45.5
       parent: 2
   - uid: 11759
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,31.5
       parent: 2
   - uid: 11760
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,31.5
       parent: 2
   - uid: 11767
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,33.5
       parent: 2
   - uid: 11769
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,34.5
       parent: 2
   - uid: 11770
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,34.5
       parent: 2
   - uid: 11772
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,35.5
       parent: 2
   - uid: 11801
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,40.5
       parent: 2
   - uid: 11804
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,31.5
       parent: 2
   - uid: 11806
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,31.5
       parent: 2
   - uid: 11810
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,33.5
       parent: 2
   - uid: 11811
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,34.5
       parent: 2
   - uid: 11817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,34.5
       parent: 2
   - uid: 11819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,9.5
       parent: 2
   - uid: 11914
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,36.5
       parent: 2
   - uid: 11923
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,9.5
       parent: 2
   - uid: 11924
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,7.5
       parent: 2
   - uid: 11926
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,8.5
       parent: 2
   - uid: 11930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,10.5
       parent: 2
   - uid: 11935
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,44.5
       parent: 2
   - uid: 11936
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,44.5
       parent: 2
   - uid: 11937
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,44.5
       parent: 2
   - uid: 11944
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,44.5
       parent: 2
   - uid: 11945
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,43.5
       parent: 2
   - uid: 11946
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,42.5
       parent: 2
   - uid: 11949
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,43.5
       parent: 2
   - uid: 11950
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,16.5
       parent: 2
   - uid: 11951
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,41.5
       parent: 2
   - uid: 11955
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,42.5
       parent: 2
   - uid: 11956
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,15.5
       parent: 2
   - uid: 11959
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,-28.5
       parent: 2
   - uid: 11962
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-29.5
       parent: 2
   - uid: 11963
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-30.5
       parent: 2
   - uid: 11964
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-31.5
       parent: 2
   - uid: 11965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-32.5
       parent: 2
   - uid: 11970
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,44.5
       parent: 2
   - uid: 11971
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-20.5
       parent: 2
   - uid: 11972
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-19.5
       parent: 2
   - uid: 11973
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-17.5
       parent: 2
   - uid: 11974
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-26.5
       parent: 2
   - uid: 11975
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-28.5
       parent: 2
   - uid: 11976
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-28.5
       parent: 2
   - uid: 11981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,43.5
       parent: 2
   - uid: 11982
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,43.5
       parent: 2
   - uid: 11983
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,44.5
       parent: 2
   - uid: 11984
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,44.5
       parent: 2
   - uid: 12104
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-27.5
       parent: 2
   - uid: 12115
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-26.5
       parent: 2
   - uid: 12117
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,36.5
       parent: 2
   - uid: 12119
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,45.5
       parent: 2
   - uid: 12120
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,35.5
       parent: 2
   - uid: 12121
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,47.5
       parent: 2
   - uid: 12128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,46.5
       parent: 2
   - uid: 12134
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,42.5
       parent: 2
   - uid: 12148
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,42.5
       parent: 2
   - uid: 12149
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,45.5
       parent: 2
   - uid: 12169
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,45.5
       parent: 2
   - uid: 12170
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,45.5
       parent: 2
   - uid: 12171
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,45.5
       parent: 2
   - uid: 12175
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,43.5
       parent: 2
   - uid: 12176
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,-14.5
       parent: 2
   - uid: 12177
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,-13.5
       parent: 2
   - uid: 12178
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,-12.5
       parent: 2
   - uid: 12234
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,6.5
       parent: 2
   - uid: 12256
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-7.5
       parent: 2
   - uid: 12285
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,9.5
       parent: 2
   - uid: 12321
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,31.5
       parent: 2
   - uid: 12339
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,4.5
       parent: 2
   - uid: 12340
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-35.5
       parent: 2
   - uid: 12344
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,35.5
       parent: 2
   - uid: 12345
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,44.5
       parent: 2
   - uid: 12347
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,36.5
       parent: 2
   - uid: 12379
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,31.5
       parent: 2
   - uid: 12398
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,0.5
       parent: 2
   - uid: 12399
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-0.5
       parent: 2
   - uid: 12400
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-3.5
       parent: 2
   - uid: 12401
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-0.5
       parent: 2
   - uid: 12403
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,-3.5
       parent: 2
   - uid: 12404
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-2.5
       parent: 2
   - uid: 12407
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,36.5
       parent: 2
   - uid: 12408
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,41.5
       parent: 2
   - uid: 12409
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,40.5
       parent: 2
   - uid: 12410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,42.5
       parent: 2
   - uid: 12411
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,39.5
       parent: 2
   - uid: 12412
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,44.5
       parent: 2
   - uid: 12413
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,43.5
       parent: 2
   - uid: 12414
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,38.5
       parent: 2
   - uid: 12415
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,46.5
       parent: 2
   - uid: 12416
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,45.5
       parent: 2
   - uid: 12417
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,47.5
       parent: 2
   - uid: 12419
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,37.5
       parent: 2
   - uid: 12424
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,38.5
       parent: 2
   - uid: 12431
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,39.5
       parent: 2
   - uid: 12434
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,40.5
       parent: 2
   - uid: 12436
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-9.5
       parent: 2
   - uid: 12439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,12.5
       parent: 2
   - uid: 12440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-13.5
       parent: 2
   - uid: 12449
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-27.5
       parent: 2
   - uid: 12458
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-11.5
       parent: 2
   - uid: 12469
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,44.5
       parent: 2
   - uid: 12493
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-10.5
       parent: 2
   - uid: 12500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-9.5
       parent: 2
   - uid: 12501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-8.5
       parent: 2
   - uid: 12502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-2.5
       parent: 2
   - uid: 12503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-1.5
       parent: 2
   - uid: 12504
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,44.5
       parent: 2
   - uid: 12505
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,47.5
       parent: 2
   - uid: 12536
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,35.5
       parent: 2
   - uid: 12539
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,36.5
       parent: 2
   - uid: 12540
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,35.5
       parent: 2
   - uid: 12570
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,17.5
       parent: 2
   - uid: 12625
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,0.5
       parent: 2
   - uid: 12649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-21.5
       parent: 2
   - uid: 12650
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-21.5
       parent: 2
   - uid: 12651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-21.5
       parent: 2
   - uid: 12652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-21.5
       parent: 2
   - uid: 12653
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-22.5
       parent: 2
   - uid: 12654
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-24.5
       parent: 2
   - uid: 12655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-25.5
       parent: 2
   - uid: 12656
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-25.5
       parent: 2
   - uid: 12657
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-25.5
       parent: 2
   - uid: 12658
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-25.5
       parent: 2
   - uid: 12659
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-24.5
       parent: 2
   - uid: 12660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-22.5
       parent: 2
   - uid: 12662
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-24.5
       parent: 2
   - uid: 12664
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-22.5
       parent: 2
   - uid: 12670
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,0.5
       parent: 2
   - uid: 12824
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,0.5
       parent: 2
   - uid: 12833
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,0.5
       parent: 2
   - uid: 12852
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,0.5
       parent: 2
   - uid: 12853
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,6.5
       parent: 2
   - uid: 12854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,6.5
       parent: 2
   - uid: 12856
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,6.5
       parent: 2
   - uid: 12888
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,6.5
       parent: 2
   - uid: 12892
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,6.5
       parent: 2
   - uid: 12893
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,5.5
       parent: 2
   - uid: 12894
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,5.5
       parent: 2
   - uid: 12907
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,5.5
       parent: 2
   - uid: 12909
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,5.5
       parent: 2
   - uid: 12911
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,6.5
       parent: 2
   - uid: 12913
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,6.5
       parent: 2
   - uid: 12923
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,6.5
       parent: 2
   - uid: 12925
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,0.5
       parent: 2
   - uid: 12931
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,0.5
       parent: 2
   - uid: 12979
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-30.5
       parent: 2
   - uid: 12987
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-1.5
       parent: 2
   - uid: 12997
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,-0.5
       parent: 2
   - uid: 12999
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,45.5
       parent: 2
   - uid: 13000
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,43.5
       parent: 2
   - uid: 13001
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,44.5
       parent: 2
   - uid: 13002
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,0.5
       parent: 2
   - uid: 13004
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,0.5
       parent: 2
   - uid: 13007
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,45.5
       parent: 2
   - uid: 13008
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,43.5
       parent: 2
   - uid: 13009
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,44.5
       parent: 2
   - uid: 13010
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,45.5
       parent: 2
   - uid: 13012
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,1.5
       parent: 2
   - uid: 13013
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,45.5
       parent: 2
   - uid: 13014
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,45.5
       parent: 2
   - uid: 13026
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,2.5
       parent: 2
   - uid: 13028
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,3.5
       parent: 2
   - uid: 13029
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,4.5
       parent: 2
   - uid: 13030
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,5.5
       parent: 2
   - uid: 13045
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,6.5
       parent: 2
   - uid: 13054
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,6.5
       parent: 2
   - uid: 13055
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,6.5
       parent: 2
   - uid: 13056
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,6.5
       parent: 2
   - uid: 13057
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,6.5
       parent: 2
   - uid: 13058
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,5.5
       parent: 2
   - uid: 13059
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,1.5
       parent: 2
   - uid: 13061
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,14.5
       parent: 2
   - uid: 13062
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,0.5
       parent: 2
   - uid: 13064
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,13.5
       parent: 2
   - uid: 13065
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,16.5
       parent: 2
   - uid: 13093
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,35.5
       parent: 2
-  - uid: 13122
-    components:
-    - type: MetaData
-      flags: PvsPriority
-    - type: Transform
-      pos: -44.5,45.5
-      parent: 2
-  - uid: 13123
-    components:
-    - type: MetaData
-      flags: PvsPriority
-    - type: Transform
-      pos: -43.5,45.5
-      parent: 2
-  - uid: 13124
-    components:
-    - type: MetaData
-      flags: PvsPriority
-    - type: Transform
-      pos: -42.5,45.5
-      parent: 2
   - uid: 13125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,45.5
       parent: 2
   - uid: 13126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,45.5
       parent: 2
   - uid: 13127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,45.5
       parent: 2
   - uid: 13128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,45.5
       parent: 2
   - uid: 13129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,45.5
       parent: 2
   - uid: 13130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,45.5
       parent: 2
   - uid: 13131
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,45.5
       parent: 2
   - uid: 13132
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,45.5
       parent: 2
   - uid: 13159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,44.5
       parent: 2
   - uid: 13225
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,13.5
       parent: 2
   - uid: 13226
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-64.5
       parent: 2
   - uid: 13229
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,13.5
       parent: 2
   - uid: 13232
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,13.5
       parent: 2
   - uid: 13233
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,16.5
       parent: 2
   - uid: 13236
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,15.5
       parent: 2
   - uid: 13239
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,14.5
       parent: 2
   - uid: 13240
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,15.5
       parent: 2
   - uid: 13244
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,16.5
       parent: 2
   - uid: 13476
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,32.5
       parent: 2
   - uid: 13477
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,33.5
       parent: 2
   - uid: 13479
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,33.5
       parent: 2
   - uid: 14602
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,32.5
       parent: 2
   - uid: 14843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-56.5
       parent: 2
   - uid: 14844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-58.5
       parent: 2
   - uid: 14846
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-57.5
       parent: 2
   - uid: 14847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-58.5
       parent: 2
   - uid: 14848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-59.5
       parent: 2
   - uid: 14851
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-64.5
       parent: 2
   - uid: 14857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-43.5
       parent: 2
   - uid: 14858
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-41.5
       parent: 2
   - uid: 14859
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-41.5
       parent: 2
   - uid: 17061
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-9.5
       parent: 2
   - uid: 17093
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,12.5
       parent: 2
@@ -98714,6084 +94135,4346 @@ entities:
   entities:
   - uid: 5
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,6.5
       parent: 2
   - uid: 51
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,5.5
       parent: 2
   - uid: 61
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,2.5
       parent: 2
   - uid: 74
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,5.5
       parent: 2
   - uid: 75
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,6.5
       parent: 2
   - uid: 76
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,7.5
       parent: 2
   - uid: 77
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,8.5
       parent: 2
   - uid: 80
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,5.5
       parent: 2
   - uid: 81
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,6.5
       parent: 2
   - uid: 82
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,7.5
       parent: 2
   - uid: 83
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,8.5
       parent: 2
   - uid: 84
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,9.5
       parent: 2
   - uid: 85
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,5.5
       parent: 2
   - uid: 86
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,6.5
       parent: 2
   - uid: 89
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,9.5
       parent: 2
   - uid: 90
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,5.5
       parent: 2
   - uid: 91
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,6.5
       parent: 2
   - uid: 94
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,9.5
       parent: 2
   - uid: 96
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,6.5
       parent: 2
   - uid: 98
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,8.5
       parent: 2
   - uid: 99
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,9.5
       parent: 2
   - uid: 100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,8.5
       parent: 2
   - uid: 102
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,9.5
       parent: 2
   - uid: 105
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,1.5
       parent: 2
   - uid: 108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,6.5
       parent: 2
   - uid: 111
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,6.5
       parent: 2
   - uid: 151
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-11.5
       parent: 2
   - uid: 154
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-13.5
       parent: 2
   - uid: 155
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-12.5
       parent: 2
   - uid: 157
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-10.5
       parent: 2
   - uid: 158
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-17.5
       parent: 2
   - uid: 159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-23.5
       parent: 2
   - uid: 163
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-30.5
       parent: 2
   - uid: 165
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-11.5
       parent: 2
   - uid: 166
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-12.5
       parent: 2
   - uid: 167
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-13.5
       parent: 2
   - uid: 168
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-14.5
       parent: 2
   - uid: 170
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-20.5
       parent: 2
   - uid: 171
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-20.5
       parent: 2
   - uid: 172
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-19.5
       parent: 2
   - uid: 173
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-19.5
       parent: 2
   - uid: 176
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-12.5
       parent: 2
   - uid: 177
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-13.5
       parent: 2
   - uid: 178
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-14.5
       parent: 2
   - uid: 181
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-21.5
       parent: 2
   - uid: 183
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-18.5
       parent: 2
   - uid: 190
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-20.5
       parent: 2
   - uid: 191
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-21.5
       parent: 2
   - uid: 192
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-21.5
       parent: 2
   - uid: 193
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-18.5
       parent: 2
   - uid: 199
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-11.5
       parent: 2
   - uid: 202
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-10.5
       parent: 2
   - uid: 203
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
   - uid: 212
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-8.5
       parent: 2
   - uid: 213
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-9.5
       parent: 2
   - uid: 214
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-10.5
       parent: 2
   - uid: 215
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-8.5
       parent: 2
   - uid: 216
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-9.5
       parent: 2
   - uid: 217
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-10.5
       parent: 2
   - uid: 218
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-9.5
       parent: 2
   - uid: 219
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-10.5
       parent: 2
   - uid: 222
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-17.5
       parent: 2
   - uid: 285
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,2.5
       parent: 2
   - uid: 337
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,8.5
       parent: 2
   - uid: 338
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,9.5
       parent: 2
   - uid: 339
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,8.5
       parent: 2
   - uid: 340
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,9.5
       parent: 2
   - uid: 341
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,8.5
       parent: 2
   - uid: 342
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,9.5
       parent: 2
   - uid: 344
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,9.5
       parent: 2
   - uid: 345
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,9.5
       parent: 2
   - uid: 346
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,9.5
       parent: 2
   - uid: 375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-18.5
       parent: 2
   - uid: 383
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,14.5
       parent: 2
   - uid: 446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-16.5
       parent: 2
   - uid: 507
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,12.5
       parent: 2
   - uid: 509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,12.5
       parent: 2
   - uid: 511
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,11.5
       parent: 2
   - uid: 525
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,10.5
       parent: 2
   - uid: 528
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,16.5
       parent: 2
   - uid: 534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,12.5
       parent: 2
   - uid: 565
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,5.5
       parent: 2
   - uid: 566
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,6.5
       parent: 2
   - uid: 568
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,7.5
       parent: 2
   - uid: 569
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,8.5
       parent: 2
   - uid: 570
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,8.5
       parent: 2
   - uid: 571
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,9.5
       parent: 2
   - uid: 572
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,5.5
       parent: 2
   - uid: 573
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,6.5
       parent: 2
   - uid: 574
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,7.5
       parent: 2
   - uid: 575
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,8.5
       parent: 2
   - uid: 577
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,13.5
       parent: 2
   - uid: 579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,15.5
       parent: 2
   - uid: 581
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,15.5
       parent: 2
   - uid: 582
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,11.5
       parent: 2
   - uid: 583
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,13.5
       parent: 2
   - uid: 590
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,11.5
       parent: 2
   - uid: 602
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,13.5
       parent: 2
   - uid: 605
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,12.5
       parent: 2
   - uid: 606
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,13.5
       parent: 2
   - uid: 607
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,14.5
       parent: 2
   - uid: 608
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,12.5
       parent: 2
   - uid: 609
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,13.5
       parent: 2
   - uid: 610
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,14.5
       parent: 2
   - uid: 611
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,12.5
       parent: 2
   - uid: 612
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,13.5
       parent: 2
   - uid: 613
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,14.5
       parent: 2
   - uid: 614
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,12.5
       parent: 2
   - uid: 615
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,13.5
       parent: 2
   - uid: 616
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,14.5
       parent: 2
   - uid: 617
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,12.5
       parent: 2
   - uid: 624
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,12.5
       parent: 2
   - uid: 628
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,12.5
       parent: 2
   - uid: 632
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,12.5
       parent: 2
   - uid: 633
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,15.5
       parent: 2
   - uid: 634
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,14.5
       parent: 2
   - uid: 635
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,13.5
       parent: 2
   - uid: 636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,12.5
       parent: 2
   - uid: 637
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,14.5
       parent: 2
   - uid: 638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,13.5
       parent: 2
   - uid: 639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,12.5
       parent: 2
   - uid: 640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,11.5
       parent: 2
   - uid: 641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,11.5
       parent: 2
   - uid: 644
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,10.5
       parent: 2
   - uid: 645
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,10.5
       parent: 2
   - uid: 646
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,10.5
       parent: 2
   - uid: 647
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,10.5
       parent: 2
   - uid: 648
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,11.5
       parent: 2
   - uid: 650
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,11.5
       parent: 2
   - uid: 651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,12.5
       parent: 2
   - uid: 652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,13.5
       parent: 2
   - uid: 657
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,16.5
       parent: 2
   - uid: 658
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,17.5
       parent: 2
   - uid: 659
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,16.5
       parent: 2
   - uid: 660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,17.5
       parent: 2
   - uid: 661
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,16.5
       parent: 2
   - uid: 662
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,17.5
       parent: 2
   - uid: 663
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,18.5
       parent: 2
   - uid: 665
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,17.5
       parent: 2
   - uid: 666
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,16.5
       parent: 2
   - uid: 668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,12.5
       parent: 2
   - uid: 669
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,14.5
       parent: 2
   - uid: 670
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,15.5
       parent: 2
   - uid: 671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,14.5
       parent: 2
   - uid: 672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,15.5
       parent: 2
   - uid: 674
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,13.5
       parent: 2
   - uid: 675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,13.5
       parent: 2
   - uid: 676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,13.5
       parent: 2
   - uid: 677
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,11.5
       parent: 2
   - uid: 678
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,12.5
       parent: 2
   - uid: 679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,12.5
       parent: 2
   - uid: 680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,13.5
       parent: 2
   - uid: 681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,11.5
       parent: 2
   - uid: 682
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,10.5
       parent: 2
   - uid: 683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,9.5
       parent: 2
   - uid: 684
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,11.5
       parent: 2
   - uid: 685
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,10.5
       parent: 2
   - uid: 686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,9.5
       parent: 2
   - uid: 687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,11.5
       parent: 2
   - uid: 688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,10.5
       parent: 2
   - uid: 689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,9.5
       parent: 2
   - uid: 690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,8.5
       parent: 2
   - uid: 691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,8.5
       parent: 2
   - uid: 693
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,7.5
       parent: 2
   - uid: 749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,5.5
       parent: 2
   - uid: 753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-11.5
       parent: 2
   - uid: 759
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
   - uid: 760
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-11.5
       parent: 2
   - uid: 792
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-14.5
       parent: 2
   - uid: 794
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-12.5
       parent: 2
   - uid: 795
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-13.5
       parent: 2
   - uid: 796
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-13.5
       parent: 2
   - uid: 797
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
   - uid: 799
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-12.5
       parent: 2
   - uid: 841
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-25.5
       parent: 2
   - uid: 876
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
   - uid: 879
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-26.5
       parent: 2
   - uid: 883
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-20.5
       parent: 2
   - uid: 884
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-20.5
       parent: 2
   - uid: 912
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-29.5
       parent: 2
   - uid: 913
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-29.5
       parent: 2
   - uid: 914
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-28.5
       parent: 2
   - uid: 915
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-29.5
       parent: 2
   - uid: 916
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-28.5
       parent: 2
   - uid: 917
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-28.5
       parent: 2
   - uid: 918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-27.5
       parent: 2
   - uid: 919
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-26.5
       parent: 2
   - uid: 920
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-26.5
       parent: 2
   - uid: 921
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-26.5
       parent: 2
   - uid: 922
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-23.5
       parent: 2
   - uid: 923
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-23.5
       parent: 2
   - uid: 924
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-23.5
       parent: 2
   - uid: 925
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-24.5
       parent: 2
   - uid: 926
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-25.5
       parent: 2
   - uid: 928
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-27.5
       parent: 2
   - uid: 930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-26.5
       parent: 2
   - uid: 949
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-27.5
       parent: 2
   - uid: 950
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-26.5
       parent: 2
   - uid: 951
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-25.5
       parent: 2
   - uid: 952
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-24.5
       parent: 2
   - uid: 953
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-23.5
       parent: 2
   - uid: 954
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-21.5
       parent: 2
   - uid: 955
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-22.5
       parent: 2
   - uid: 959
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-18.5
       parent: 2
   - uid: 961
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-22.5
       parent: 2
   - uid: 962
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-23.5
       parent: 2
   - uid: 963
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-24.5
       parent: 2
   - uid: 964
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-22.5
       parent: 2
   - uid: 965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-23.5
       parent: 2
   - uid: 966
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-24.5
       parent: 2
   - uid: 967
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-22.5
       parent: 2
   - uid: 968
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-23.5
       parent: 2
   - uid: 969
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-24.5
       parent: 2
   - uid: 971
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-23.5
       parent: 2
   - uid: 972
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-24.5
       parent: 2
   - uid: 973
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-30.5
       parent: 2
   - uid: 974
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-31.5
       parent: 2
   - uid: 978
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-26.5
       parent: 2
   - uid: 979
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-25.5
       parent: 2
   - uid: 980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-25.5
       parent: 2
   - uid: 981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-31.5
       parent: 2
   - uid: 982
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-29.5
       parent: 2
   - uid: 983
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-30.5
       parent: 2
   - uid: 984
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-29.5
       parent: 2
   - uid: 987
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-31.5
       parent: 2
   - uid: 989
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-32.5
       parent: 2
   - uid: 990
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-32.5
       parent: 2
   - uid: 991
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-33.5
       parent: 2
   - uid: 996
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-32.5
       parent: 2
   - uid: 1045
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-18.5
       parent: 2
   - uid: 1048
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-19.5
       parent: 2
   - uid: 1050
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
   - uid: 1061
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-19.5
       parent: 2
   - uid: 1064
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-19.5
       parent: 2
   - uid: 1114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,19.5
       parent: 2
   - uid: 1136
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,1.5
       parent: 2
   - uid: 1137
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,2.5
       parent: 2
   - uid: 1138
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,3.5
       parent: 2
   - uid: 1139
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,2.5
       parent: 2
   - uid: 1141
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,4.5
       parent: 2
   - uid: 1146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,13.5
       parent: 2
   - uid: 1149
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,2.5
       parent: 2
   - uid: 1151
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,1.5
       parent: 2
   - uid: 1152
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,1.5
       parent: 2
   - uid: 1153
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,0.5
       parent: 2
   - uid: 1154
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
   - uid: 1155
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,1.5
       parent: 2
   - uid: 1156
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,0.5
       parent: 2
   - uid: 1157
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-0.5
       parent: 2
   - uid: 1159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-0.5
       parent: 2
   - uid: 1160
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-0.5
       parent: 2
   - uid: 1161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-1.5
       parent: 2
   - uid: 1162
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-1.5
       parent: 2
   - uid: 1184
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-16.5
       parent: 2
   - uid: 1185
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-17.5
       parent: 2
   - uid: 1186
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-18.5
       parent: 2
   - uid: 1189
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-17.5
       parent: 2
   - uid: 1190
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-18.5
       parent: 2
   - uid: 1191
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-19.5
       parent: 2
   - uid: 1204
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-59.5
       parent: 2
   - uid: 1254
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-22.5
       parent: 2
   - uid: 1262
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-21.5
       parent: 2
   - uid: 1286
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-23.5
       parent: 2
   - uid: 1288
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-22.5
       parent: 2
   - uid: 1312
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-21.5
       parent: 2
   - uid: 1395
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-21.5
       parent: 2
   - uid: 1396
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-22.5
       parent: 2
   - uid: 1397
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-23.5
       parent: 2
   - uid: 1680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-49.5
       parent: 2
   - uid: 1828
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-24.5
       parent: 2
   - uid: 1833
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-13.5
       parent: 2
   - uid: 1861
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-19.5
       parent: 2
   - uid: 1877
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-29.5
       parent: 2
   - uid: 1897
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-11.5
       parent: 2
   - uid: 1898
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
   - uid: 1899
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
   - uid: 1900
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-12.5
       parent: 2
   - uid: 1901
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-12.5
       parent: 2
   - uid: 1902
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-12.5
       parent: 2
   - uid: 1903
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-13.5
       parent: 2
   - uid: 1904
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-14.5
       parent: 2
   - uid: 1905
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-14.5
       parent: 2
   - uid: 1906
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
   - uid: 1908
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-13.5
       parent: 2
   - uid: 1909
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-15.5
       parent: 2
   - uid: 1910
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-14.5
       parent: 2
   - uid: 1911
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,-13.5
       parent: 2
   - uid: 1914
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-20.5
       parent: 2
   - uid: 1933
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-21.5
       parent: 2
   - uid: 1935
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-20.5
       parent: 2
   - uid: 1937
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-20.5
       parent: 2
   - uid: 1939
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-17.5
       parent: 2
   - uid: 1941
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-17.5
       parent: 2
   - uid: 1944
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-26.5
       parent: 2
   - uid: 1945
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-25.5
       parent: 2
   - uid: 1946
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-24.5
       parent: 2
   - uid: 1947
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-23.5
       parent: 2
   - uid: 1948
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-22.5
       parent: 2
   - uid: 1949
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-21.5
       parent: 2
   - uid: 1950
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-20.5
       parent: 2
   - uid: 1955
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-26.5
       parent: 2
   - uid: 1956
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-25.5
       parent: 2
   - uid: 1957
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-24.5
       parent: 2
   - uid: 1958
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-23.5
       parent: 2
   - uid: 1959
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-22.5
       parent: 2
   - uid: 1960
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-21.5
       parent: 2
   - uid: 1975
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,0.5
       parent: 2
   - uid: 1976
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,-12.5
       parent: 2
   - uid: 1977
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-15.5
       parent: 2
   - uid: 1978
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-16.5
       parent: 2
   - uid: 1980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-20.5
       parent: 2
   - uid: 2022
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-25.5
       parent: 2
   - uid: 2023
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-24.5
       parent: 2
   - uid: 2026
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-22.5
       parent: 2
   - uid: 2055
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-44.5
       parent: 2
   - uid: 2107
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-23.5
       parent: 2
   - uid: 2108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-25.5
       parent: 2
   - uid: 2109
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-24.5
       parent: 2
   - uid: 2110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-23.5
       parent: 2
   - uid: 2114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-25.5
       parent: 2
   - uid: 2117
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-20.5
       parent: 2
   - uid: 2304
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-15.5
       parent: 2
   - uid: 2337
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-38.5
       parent: 2
   - uid: 2341
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-38.5
       parent: 2
   - uid: 2342
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-39.5
       parent: 2
   - uid: 2347
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-36.5
       parent: 2
   - uid: 2348
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-40.5
       parent: 2
   - uid: 2349
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-41.5
       parent: 2
   - uid: 2350
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-42.5
       parent: 2
   - uid: 2354
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-40.5
       parent: 2
   - uid: 2355
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-41.5
       parent: 2
   - uid: 2356
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-42.5
       parent: 2
   - uid: 2358
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-39.5
       parent: 2
   - uid: 2359
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-40.5
       parent: 2
   - uid: 2360
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-41.5
       parent: 2
   - uid: 2361
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-42.5
       parent: 2
   - uid: 2362
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-43.5
       parent: 2
   - uid: 2363
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-44.5
       parent: 2
   - uid: 2364
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-40.5
       parent: 2
   - uid: 2365
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-40.5
       parent: 2
   - uid: 2641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-20.5
       parent: 2
   - uid: 2785
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-44.5
       parent: 2
   - uid: 2877
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-43.5
       parent: 2
   - uid: 2918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-43.5
       parent: 2
   - uid: 2920
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-45.5
       parent: 2
   - uid: 2921
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-45.5
       parent: 2
   - uid: 2922
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-45.5
       parent: 2
   - uid: 2964
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-23.5
       parent: 2
   - uid: 2965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-24.5
       parent: 2
   - uid: 2966
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-25.5
       parent: 2
   - uid: 3204
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-57.5
       parent: 2
   - uid: 3205
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-47.5
       parent: 2
   - uid: 3227
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-46.5
       parent: 2
   - uid: 3231
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-46.5
       parent: 2
   - uid: 3235
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-46.5
       parent: 2
   - uid: 3236
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-46.5
       parent: 2
   - uid: 3268
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-46.5
       parent: 2
   - uid: 3275
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-46.5
       parent: 2
   - uid: 3282
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-46.5
       parent: 2
   - uid: 3289
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-46.5
       parent: 2
   - uid: 3294
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-48.5
       parent: 2
   - uid: 3295
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-47.5
       parent: 2
   - uid: 3296
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-46.5
       parent: 2
   - uid: 3301
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-46.5
       parent: 2
   - uid: 3325
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-54.5
       parent: 2
   - uid: 3326
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-55.5
       parent: 2
   - uid: 3327
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-56.5
       parent: 2
   - uid: 3330
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-54.5
       parent: 2
   - uid: 3331
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-55.5
       parent: 2
   - uid: 3332
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-56.5
       parent: 2
   - uid: 3333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-57.5
       parent: 2
   - uid: 3335
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-54.5
       parent: 2
   - uid: 3336
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-55.5
       parent: 2
   - uid: 3337
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-56.5
       parent: 2
   - uid: 3338
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-57.5
       parent: 2
   - uid: 3345
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-58.5
       parent: 2
   - uid: 3346
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-59.5
       parent: 2
   - uid: 3347
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-60.5
       parent: 2
   - uid: 3349
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-58.5
       parent: 2
   - uid: 3350
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-59.5
       parent: 2
   - uid: 3351
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-60.5
       parent: 2
   - uid: 3352
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-61.5
       parent: 2
   - uid: 3353
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-58.5
       parent: 2
   - uid: 3354
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-59.5
       parent: 2
   - uid: 3355
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-60.5
       parent: 2
   - uid: 3356
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-61.5
       parent: 2
   - uid: 3357
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-58.5
       parent: 2
   - uid: 3358
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-59.5
       parent: 2
   - uid: 3361
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-58.5
       parent: 2
   - uid: 3362
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-59.5
       parent: 2
   - uid: 3365
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-58.5
       parent: 2
   - uid: 3366
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-59.5
       parent: 2
   - uid: 3373
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-62.5
       parent: 2
   - uid: 3375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-62.5
       parent: 2
   - uid: 3377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-62.5
       parent: 2
   - uid: 3393
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,13.5
       parent: 2
   - uid: 3394
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,14.5
       parent: 2
   - uid: 3395
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,13.5
       parent: 2
   - uid: 3397
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,15.5
       parent: 2
   - uid: 3398
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,14.5
       parent: 2
   - uid: 3402
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,13.5
       parent: 2
   - uid: 3403
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,13.5
       parent: 2
   - uid: 3414
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-59.5
       parent: 2
   - uid: 3422
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-59.5
       parent: 2
   - uid: 3424
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-65.5
       parent: 2
   - uid: 3430
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-59.5
       parent: 2
   - uid: 3432
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-65.5
       parent: 2
   - uid: 3435
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-59.5
       parent: 2
   - uid: 3438
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-59.5
       parent: 2
   - uid: 3440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-65.5
       parent: 2
   - uid: 3446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-59.5
       parent: 2
   - uid: 3449
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-64.5
       parent: 2
   - uid: 3453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-60.5
       parent: 2
   - uid: 3454
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-59.5
       parent: 2
   - uid: 3468
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-64.5
       parent: 2
   - uid: 3469
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-63.5
       parent: 2
   - uid: 3473
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-59.5
       parent: 2
   - uid: 3474
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-58.5
       parent: 2
   - uid: 3479
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-63.5
       parent: 2
   - uid: 3480
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-62.5
       parent: 2
   - uid: 3484
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-58.5
       parent: 2
   - uid: 3487
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-63.5
       parent: 2
   - uid: 3488
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-62.5
       parent: 2
   - uid: 3489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-61.5
       parent: 2
   - uid: 3492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-58.5
       parent: 2
   - uid: 3497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-62.5
       parent: 2
   - uid: 3498
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-61.5
       parent: 2
   - uid: 3499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-60.5
       parent: 2
   - uid: 3500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-59.5
       parent: 2
   - uid: 3501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-58.5
       parent: 2
   - uid: 3506
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-62.5
       parent: 2
   - uid: 3507
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-61.5
       parent: 2
   - uid: 3508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-60.5
       parent: 2
   - uid: 3509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-59.5
       parent: 2
   - uid: 3510
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-58.5
       parent: 2
   - uid: 3511
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-57.5
       parent: 2
   - uid: 3512
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-56.5
       parent: 2
   - uid: 3513
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-55.5
       parent: 2
   - uid: 3514
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-54.5
       parent: 2
   - uid: 3518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-62.5
       parent: 2
   - uid: 3519
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-61.5
       parent: 2
   - uid: 3520
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-60.5
       parent: 2
   - uid: 3521
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-59.5
       parent: 2
   - uid: 3522
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-58.5
       parent: 2
   - uid: 3523
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-57.5
       parent: 2
   - uid: 3524
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-56.5
       parent: 2
   - uid: 3525
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-55.5
       parent: 2
   - uid: 3526
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-54.5
       parent: 2
   - uid: 3531
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-61.5
       parent: 2
   - uid: 3532
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-60.5
       parent: 2
   - uid: 3533
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-59.5
       parent: 2
   - uid: 3534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-58.5
       parent: 2
   - uid: 3535
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-57.5
       parent: 2
   - uid: 3537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-47.5
       parent: 2
   - uid: 3538
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-48.5
       parent: 2
   - uid: 3587
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-53.5
       parent: 2
   - uid: 3590
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-55.5
       parent: 2
   - uid: 3600
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-45.5
       parent: 2
   - uid: 3601
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-44.5
       parent: 2
   - uid: 3602
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-43.5
       parent: 2
   - uid: 3603
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-42.5
       parent: 2
   - uid: 3604
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-46.5
       parent: 2
   - uid: 3605
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-45.5
       parent: 2
   - uid: 3606
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-44.5
       parent: 2
   - uid: 3607
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-43.5
       parent: 2
   - uid: 3608
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-42.5
       parent: 2
   - uid: 3611
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-44.5
       parent: 2
   - uid: 3612
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-43.5
       parent: 2
   - uid: 3613
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-42.5
       parent: 2
   - uid: 3618
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-42.5
       parent: 2
   - uid: 3634
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-51.5
       parent: 2
   - uid: 3637
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-51.5
       parent: 2
   - uid: 3639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-52.5
       parent: 2
   - uid: 3640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-51.5
       parent: 2
   - uid: 3642
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-52.5
       parent: 2
   - uid: 3643
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-53.5
       parent: 2
   - uid: 3644
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-52.5
       parent: 2
   - uid: 3645
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-53.5
       parent: 2
   - uid: 3646
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-53.5
       parent: 2
   - uid: 3647
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-55.5
       parent: 2
   - uid: 3648
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-54.5
       parent: 2
   - uid: 3649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-54.5
       parent: 2
   - uid: 3651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-54.5
       parent: 2
   - uid: 3652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-54.5
       parent: 2
   - uid: 3659
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-55.5
       parent: 2
   - uid: 3660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-56.5
       parent: 2
   - uid: 3661
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-56.5
       parent: 2
   - uid: 3664
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-56.5
       parent: 2
   - uid: 3665
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-56.5
       parent: 2
   - uid: 3666
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-58.5
       parent: 2
   - uid: 3667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-56.5
       parent: 2
   - uid: 3668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-57.5
       parent: 2
   - uid: 3669
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-58.5
       parent: 2
   - uid: 3670
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-55.5
       parent: 2
   - uid: 3671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-55.5
       parent: 2
   - uid: 3672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-58.5
       parent: 2
   - uid: 3673
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-55.5
       parent: 2
   - uid: 3674
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-57.5
       parent: 2
   - uid: 3675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-58.5
       parent: 2
   - uid: 3691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-59.5
       parent: 2
   - uid: 3694
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-59.5
       parent: 2
   - uid: 3695
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-60.5
       parent: 2
   - uid: 3697
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-59.5
       parent: 2
   - uid: 3698
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-60.5
       parent: 2
   - uid: 3700
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-59.5
       parent: 2
   - uid: 3701
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-60.5
       parent: 2
   - uid: 3702
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-61.5
       parent: 2
   - uid: 3723
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-45.5
       parent: 2
   - uid: 3724
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-44.5
       parent: 2
   - uid: 3725
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-43.5
       parent: 2
   - uid: 3726
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-42.5
       parent: 2
   - uid: 3727
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-41.5
       parent: 2
   - uid: 3728
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-45.5
       parent: 2
   - uid: 3729
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-44.5
       parent: 2
   - uid: 3730
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-43.5
       parent: 2
   - uid: 3731
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-42.5
       parent: 2
   - uid: 3732
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-41.5
       parent: 2
   - uid: 3733
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-45.5
       parent: 2
   - uid: 3734
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-44.5
       parent: 2
   - uid: 3735
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-43.5
       parent: 2
   - uid: 3736
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-42.5
       parent: 2
   - uid: 3737
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-41.5
       parent: 2
   - uid: 3739
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-44.5
       parent: 2
   - uid: 3740
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-43.5
       parent: 2
   - uid: 3741
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-42.5
       parent: 2
   - uid: 3743
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-46.5
       parent: 2
   - uid: 3756
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-41.5
       parent: 2
   - uid: 3757
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-40.5
       parent: 2
   - uid: 3758
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-39.5
       parent: 2
   - uid: 3761
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-41.5
       parent: 2
   - uid: 3762
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-40.5
       parent: 2
   - uid: 3763
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-39.5
       parent: 2
   - uid: 3764
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-38.5
       parent: 2
   - uid: 3765
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-37.5
       parent: 2
   - uid: 3766
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-41.5
       parent: 2
   - uid: 3767
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-40.5
       parent: 2
   - uid: 3769
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-38.5
       parent: 2
   - uid: 3770
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-37.5
       parent: 2
   - uid: 3771
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-41.5
       parent: 2
   - uid: 3774
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-38.5
       parent: 2
   - uid: 3775
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-37.5
       parent: 2
   - uid: 3780
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-36.5
       parent: 2
   - uid: 3782
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-36.5
       parent: 2
   - uid: 3789
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-36.5
       parent: 2
   - uid: 3790
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-40.5
       parent: 2
   - uid: 3791
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-39.5
       parent: 2
   - uid: 3792
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-38.5
       parent: 2
   - uid: 3793
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-37.5
       parent: 2
   - uid: 3794
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-36.5
       parent: 2
   - uid: 3797
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-40.5
       parent: 2
   - uid: 3798
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-39.5
       parent: 2
   - uid: 3799
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-40.5
       parent: 2
   - uid: 3800
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-39.5
       parent: 2
   - uid: 3801
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-38.5
       parent: 2
   - uid: 3802
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-37.5
       parent: 2
   - uid: 3803
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-36.5
       parent: 2
   - uid: 3816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,19.5
       parent: 2
   - uid: 3818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,19.5
       parent: 2
   - uid: 3819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,18.5
       parent: 2
   - uid: 3822
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-28.5
       parent: 2
   - uid: 3826
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-28.5
       parent: 2
   - uid: 3831
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-27.5
       parent: 2
   - uid: 3832
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-28.5
       parent: 2
   - uid: 3833
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-27.5
       parent: 2
   - uid: 3834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-26.5
       parent: 2
   - uid: 3835
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-28.5
       parent: 2
   - uid: 3836
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-31.5
       parent: 2
   - uid: 3838
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-31.5
       parent: 2
   - uid: 3839
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,17.5
       parent: 2
   - uid: 3843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-31.5
       parent: 2
   - uid: 3844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-30.5
       parent: 2
   - uid: 3845
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-31.5
       parent: 2
   - uid: 3846
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-31.5
       parent: 2
   - uid: 3847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-32.5
       parent: 2
   - uid: 3848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-33.5
       parent: 2
   - uid: 3849
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-32.5
       parent: 2
   - uid: 3850
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-33.5
       parent: 2
   - uid: 3851
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-32.5
       parent: 2
   - uid: 3854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-34.5
       parent: 2
   - uid: 3855
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-35.5
       parent: 2
   - uid: 3856
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-36.5
       parent: 2
   - uid: 3857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-37.5
       parent: 2
   - uid: 3858
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-38.5
       parent: 2
   - uid: 3859
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-38.5
       parent: 2
   - uid: 3860
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-34.5
       parent: 2
   - uid: 3861
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-38.5
       parent: 2
   - uid: 3865
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-38.5
       parent: 2
   - uid: 3873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-39.5
       parent: 2
   - uid: 3874
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,18.5
       parent: 2
   - uid: 3880
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-39.5
       parent: 2
   - uid: 3887
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-39.5
       parent: 2
   - uid: 3888
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,17.5
       parent: 2
   - uid: 3889
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,18.5
       parent: 2
   - uid: 3890
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,18.5
       parent: 2
   - uid: 3891
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,19.5
       parent: 2
   - uid: 3893
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-35.5
       parent: 2
   - uid: 3894
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-28.5
       parent: 2
   - uid: 3897
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,17.5
       parent: 2
   - uid: 3907
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,18.5
       parent: 2
   - uid: 3908
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,19.5
       parent: 2
   - uid: 3920
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-37.5
       parent: 2
   - uid: 3942
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-15.5
       parent: 2
   - uid: 3954
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-15.5
       parent: 2
   - uid: 3958
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-15.5
       parent: 2
   - uid: 3959
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-15.5
       parent: 2
   - uid: 3960
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-15.5
       parent: 2
   - uid: 4030
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-27.5
       parent: 2
   - uid: 4213
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-41.5
       parent: 2
   - uid: 4214
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-41.5
       parent: 2
   - uid: 4215
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-41.5
       parent: 2
   - uid: 4251
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-50.5
       parent: 2
   - uid: 4252
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-50.5
       parent: 2
   - uid: 4253
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-51.5
       parent: 2
   - uid: 4254
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-51.5
       parent: 2
   - uid: 4255
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-50.5
       parent: 2
   - uid: 4256
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-50.5
       parent: 2
   - uid: 4257
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-49.5
       parent: 2
   - uid: 4258
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-49.5
       parent: 2
   - uid: 4259
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-48.5
       parent: 2
   - uid: 4260
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-48.5
       parent: 2
   - uid: 4261
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-48.5
       parent: 2
   - uid: 4271
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-57.5
       parent: 2
   - uid: 4272
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-48.5
       parent: 2
   - uid: 4292
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-47.5
       parent: 2
   - uid: 4416
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-39.5
       parent: 2
   - uid: 5537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-39.5
       parent: 2
   - uid: 5686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,17.5
       parent: 2
   - uid: 5688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,18.5
       parent: 2
   - uid: 5873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,34.5
       parent: 2
   - uid: 6309
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,24.5
       parent: 2
   - uid: 6313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,23.5
       parent: 2
   - uid: 6315
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,25.5
       parent: 2
   - uid: 6316
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,23.5
       parent: 2
   - uid: 6317
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,24.5
       parent: 2
   - uid: 6318
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,25.5
       parent: 2
   - uid: 6326
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,43.5
       parent: 2
   - uid: 6328
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,43.5
       parent: 2
   - uid: 6331
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,43.5
       parent: 2
   - uid: 6332
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,43.5
       parent: 2
   - uid: 6334
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,43.5
       parent: 2
   - uid: 6335
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,43.5
       parent: 2
   - uid: 6373
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,42.5
       parent: 2
   - uid: 6375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,40.5
       parent: 2
   - uid: 6376
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,42.5
       parent: 2
   - uid: 6377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,41.5
       parent: 2
   - uid: 6378
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,40.5
       parent: 2
   - uid: 6382
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,39.5
       parent: 2
   - uid: 6388
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,40.5
       parent: 2
   - uid: 6389
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,41.5
       parent: 2
   - uid: 6390
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,42.5
       parent: 2
   - uid: 6391
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,40.5
       parent: 2
   - uid: 6392
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,41.5
       parent: 2
   - uid: 6393
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,42.5
       parent: 2
   - uid: 6400
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,42.5
       parent: 2
   - uid: 6401
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,41.5
       parent: 2
   - uid: 6402
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,40.5
       parent: 2
   - uid: 6404
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,42.5
       parent: 2
   - uid: 6405
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,41.5
       parent: 2
   - uid: 6406
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,40.5
       parent: 2
   - uid: 6407
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,39.5
       parent: 2
   - uid: 6408
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,42.5
       parent: 2
   - uid: 6409
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,41.5
       parent: 2
   - uid: 6410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,40.5
       parent: 2
   - uid: 6411
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,39.5
       parent: 2
   - uid: 6412
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,42.5
       parent: 2
   - uid: 6413
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,41.5
       parent: 2
   - uid: 6414
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,40.5
       parent: 2
   - uid: 6415
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,39.5
       parent: 2
   - uid: 6428
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,43.5
       parent: 2
   - uid: 6429
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,42.5
       parent: 2
   - uid: 6430
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,41.5
       parent: 2
   - uid: 6431
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,40.5
       parent: 2
   - uid: 6438
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,43.5
       parent: 2
   - uid: 6439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,42.5
       parent: 2
   - uid: 6440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,41.5
       parent: 2
   - uid: 6441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,40.5
       parent: 2
   - uid: 6442
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,39.5
       parent: 2
   - uid: 6448
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,43.5
       parent: 2
   - uid: 6449
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,42.5
       parent: 2
   - uid: 6450
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,41.5
       parent: 2
   - uid: 6451
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,40.5
       parent: 2
   - uid: 6452
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,39.5
       parent: 2
   - uid: 6453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,39.5
       parent: 2
   - uid: 6454
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,40.5
       parent: 2
   - uid: 6455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,41.5
       parent: 2
   - uid: 6456
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,42.5
       parent: 2
   - uid: 6457
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,43.5
       parent: 2
   - uid: 6478
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,45.5
       parent: 2
   - uid: 6491
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,40.5
       parent: 2
   - uid: 6492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,41.5
       parent: 2
   - uid: 6493
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,42.5
       parent: 2
   - uid: 6494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,43.5
       parent: 2
   - uid: 6496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,40.5
       parent: 2
   - uid: 6497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,41.5
       parent: 2
   - uid: 6498
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,42.5
       parent: 2
   - uid: 6499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,43.5
       parent: 2
   - uid: 6501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,40.5
       parent: 2
   - uid: 6502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,41.5
       parent: 2
   - uid: 6503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,42.5
       parent: 2
   - uid: 6504
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,43.5
       parent: 2
   - uid: 6506
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,40.5
       parent: 2
   - uid: 6507
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,41.5
       parent: 2
   - uid: 6508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,42.5
       parent: 2
   - uid: 6509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,43.5
       parent: 2
   - uid: 6510
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,44.5
       parent: 2
   - uid: 6511
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,40.5
       parent: 2
   - uid: 6512
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,41.5
       parent: 2
   - uid: 6513
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,42.5
       parent: 2
   - uid: 6514
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,43.5
       parent: 2
   - uid: 6515
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,44.5
       parent: 2
   - uid: 6518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,44.5
       parent: 2
   - uid: 6519
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,43.5
       parent: 2
   - uid: 6520
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,42.5
       parent: 2
   - uid: 6521
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,41.5
       parent: 2
   - uid: 6522
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,40.5
       parent: 2
   - uid: 6523
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,44.5
       parent: 2
   - uid: 6524
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,43.5
       parent: 2
   - uid: 6543
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-40.5
       parent: 2
   - uid: 6593
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,36.5
       parent: 2
   - uid: 6594
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,36.5
       parent: 2
   - uid: 6595
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,36.5
       parent: 2
   - uid: 6683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,35.5
       parent: 2
   - uid: 6684
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,34.5
       parent: 2
   - uid: 6685
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,35.5
       parent: 2
   - uid: 6686
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,34.5
       parent: 2
   - uid: 6687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,35.5
       parent: 2
   - uid: 6688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,34.5
       parent: 2
   - uid: 6689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,35.5
       parent: 2
   - uid: 6690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,34.5
       parent: 2
   - uid: 6691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,34.5
       parent: 2
   - uid: 6692
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,33.5
       parent: 2
   - uid: 6694
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,33.5
       parent: 2
   - uid: 6698
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,33.5
       parent: 2
   - uid: 6700
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,33.5
       parent: 2
   - uid: 6701
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,32.5
       parent: 2
   - uid: 6708
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,31.5
       parent: 2
   - uid: 6714
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,20.5
       parent: 2
   - uid: 6715
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,21.5
       parent: 2
   - uid: 6717
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,21.5
       parent: 2
   - uid: 6718
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,22.5
       parent: 2
   - uid: 6731
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,22.5
       parent: 2
   - uid: 6732
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,23.5
       parent: 2
   - uid: 6733
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,23.5
       parent: 2
   - uid: 6758
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,22.5
       parent: 2
   - uid: 6759
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,25.5
       parent: 2
   - uid: 6760
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,24.5
       parent: 2
   - uid: 6761
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,25.5
       parent: 2
   - uid: 6762
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,24.5
       parent: 2
   - uid: 6763
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,25.5
       parent: 2
   - uid: 6764
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,26.5
       parent: 2
   - uid: 6766
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,26.5
       parent: 2
   - uid: 6768
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,26.5
       parent: 2
   - uid: 6769
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,27.5
       parent: 2
   - uid: 6770
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,26.5
       parent: 2
   - uid: 6771
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,27.5
       parent: 2
   - uid: 6772
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,26.5
       parent: 2
   - uid: 6773
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,27.5
       parent: 2
   - uid: 6782
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,28.5
       parent: 2
   - uid: 6783
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,29.5
       parent: 2
   - uid: 6784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,28.5
       parent: 2
   - uid: 6785
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,29.5
       parent: 2
   - uid: 6786
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,30.5
       parent: 2
   - uid: 6787
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,31.5
       parent: 2
   - uid: 6788
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,32.5
       parent: 2
   - uid: 6789
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,33.5
       parent: 2
   - uid: 6790
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,34.5
       parent: 2
   - uid: 6791
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,30.5
       parent: 2
   - uid: 6792
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,31.5
       parent: 2
   - uid: 6793
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,32.5
       parent: 2
   - uid: 6794
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,33.5
       parent: 2
   - uid: 6795
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,34.5
       parent: 2
   - uid: 6796
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,30.5
       parent: 2
   - uid: 6797
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,31.5
       parent: 2
   - uid: 6798
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,32.5
       parent: 2
   - uid: 6799
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,33.5
       parent: 2
   - uid: 6800
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,34.5
       parent: 2
   - uid: 6801
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,35.5
       parent: 2
   - uid: 6802
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,35.5
       parent: 2
   - uid: 6803
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,36.5
       parent: 2
   - uid: 6971
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,14.5
       parent: 2
   - uid: 7226
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,39.5
       parent: 2
   - uid: 7227
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,39.5
       parent: 2
   - uid: 7475
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-39.5
       parent: 2
   - uid: 7816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,45.5
       parent: 2
   - uid: 7941
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,32.5
       parent: 2
   - uid: 7942
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,33.5
       parent: 2
   - uid: 7948
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,33.5
       parent: 2
   - uid: 8013
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,42.5
       parent: 2
   - uid: 8014
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,41.5
       parent: 2
   - uid: 8015
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,40.5
       parent: 2
   - uid: 8021
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,40.5
       parent: 2
   - uid: 8022
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,39.5
       parent: 2
   - uid: 8023
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,39.5
       parent: 2
   - uid: 8030
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,38.5
       parent: 2
   - uid: 8031
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,38.5
       parent: 2
   - uid: 8032
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,38.5
       parent: 2
   - uid: 8033
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,38.5
       parent: 2
   - uid: 8034
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,38.5
       parent: 2
   - uid: 8035
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,40.5
       parent: 2
   - uid: 8036
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,41.5
       parent: 2
   - uid: 8099
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,32.5
       parent: 2
   - uid: 8101
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,30.5
       parent: 2
   - uid: 8102
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,29.5
       parent: 2
   - uid: 8103
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,31.5
       parent: 2
   - uid: 8104
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,30.5
       parent: 2
   - uid: 8105
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,29.5
       parent: 2
   - uid: 8106
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,31.5
       parent: 2
   - uid: 8107
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,30.5
       parent: 2
   - uid: 8108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,29.5
       parent: 2
   - uid: 8109
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,31.5
       parent: 2
   - uid: 8110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,30.5
       parent: 2
   - uid: 8111
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,29.5
       parent: 2
   - uid: 8112
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,31.5
       parent: 2
   - uid: 8113
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,30.5
       parent: 2
   - uid: 8115
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,31.5
       parent: 2
   - uid: 8116
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,30.5
       parent: 2
   - uid: 8117
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,29.5
       parent: 2
   - uid: 8120
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,30.5
       parent: 2
   - uid: 8121
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,29.5
       parent: 2
   - uid: 8127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,32.5
       parent: 2
   - uid: 8128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,31.5
       parent: 2
   - uid: 8129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,30.5
       parent: 2
   - uid: 8263
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,28.5
       parent: 2
   - uid: 8264
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,29.5
       parent: 2
   - uid: 8265
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,28.5
       parent: 2
   - uid: 8651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,12.5
       parent: 2
   - uid: 8697
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,14.5
       parent: 2
   - uid: 8711
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,12.5
       parent: 2
   - uid: 8732
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,13.5
       parent: 2
   - uid: 8781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,35.5
       parent: 2
   - uid: 8784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,33.5
       parent: 2
   - uid: 9083
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,33.5
       parent: 2
   - uid: 9095
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,39.5
       parent: 2
   - uid: 9122
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,37.5
       parent: 2
   - uid: 9608
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,12.5
       parent: 2
   - uid: 9960
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-52.5
       parent: 2
   - uid: 10014
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,13.5
       parent: 2
   - uid: 10509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,5.5
       parent: 2
   - uid: 11750
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-48.5
       parent: 2
   - uid: 11876
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-49.5
       parent: 2
   - uid: 11881
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-50.5
       parent: 2
   - uid: 11885
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-48.5
       parent: 2
   - uid: 11888
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-51.5
       parent: 2
   - uid: 11898
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-47.5
       parent: 2
   - uid: 12332
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-51.5
       parent: 2
   - uid: 12352
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-52.5
       parent: 2
   - uid: 12353
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-50.5
       parent: 2
   - uid: 12354
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-47.5
       parent: 2
   - uid: 12358
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-52.5
       parent: 2
   - uid: 12359
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-53.5
       parent: 2
   - uid: 12360
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-53.5
       parent: 2
   - uid: 12362
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-53.5
       parent: 2
   - uid: 12368
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-53.5
       parent: 2
   - uid: 12369
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-48.5
       parent: 2
   - uid: 12373
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-49.5
       parent: 2
   - uid: 12814
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-60.5
       parent: 2
   - uid: 13153
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-33.5
       parent: 2
   - uid: 13167
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-33.5
       parent: 2
   - uid: 13255
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-34.5
       parent: 2
   - uid: 13745
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-35.5
       parent: 2
   - uid: 13764
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-51.5
       parent: 2
   - uid: 13765
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-50.5
       parent: 2
   - uid: 13957
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-39.5
       parent: 2
   - uid: 13960
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-39.5
       parent: 2
   - uid: 14534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,18.5
       parent: 2
   - uid: 14580
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,2.5
       parent: 2
   - uid: 14593
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,19.5
       parent: 2
   - uid: 14946
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,14.5
       parent: 2
   - uid: 17547
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-34.5
       parent: 2
@@ -104799,2605 +98482,1861 @@ entities:
   entities:
   - uid: 1858
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,-17.5
       parent: 2
   - uid: 3475
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-53.5
       parent: 2
   - uid: 3615
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-28.5
       parent: 2
   - uid: 3620
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-28.5
       parent: 2
   - uid: 3621
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-53.5
       parent: 2
   - uid: 3622
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-59.5
       parent: 2
   - uid: 3626
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-58.5
       parent: 2
   - uid: 3627
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-65.5
       parent: 2
   - uid: 3628
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-66.5
       parent: 2
   - uid: 3629
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-65.5
       parent: 2
   - uid: 3655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-48.5
       parent: 2
   - uid: 3656
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-49.5
       parent: 2
   - uid: 3657
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-47.5
       parent: 2
   - uid: 3678
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-46.5
       parent: 2
   - uid: 3679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-50.5
       parent: 2
   - uid: 3680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-51.5
       parent: 2
   - uid: 3681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-52.5
       parent: 2
   - uid: 3682
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-54.5
       parent: 2
   - uid: 3683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-55.5
       parent: 2
   - uid: 3684
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-56.5
       parent: 2
   - uid: 3685
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-57.5
       parent: 2
   - uid: 3696
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-60.5
       parent: 2
   - uid: 3704
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-61.5
       parent: 2
   - uid: 3710
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-62.5
       parent: 2
   - uid: 3711
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-63.5
       parent: 2
   - uid: 3750
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-64.5
       parent: 2
   - uid: 3753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-64.5
       parent: 2
   - uid: 3754
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-64.5
       parent: 2
   - uid: 3777
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-66.5
       parent: 2
   - uid: 3778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-66.5
       parent: 2
   - uid: 3781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,-66.5
       parent: 2
   - uid: 3784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-66.5
       parent: 2
   - uid: 3788
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,-67.5
       parent: 2
   - uid: 3795
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,-67.5
       parent: 2
   - uid: 3796
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-67.5
       parent: 2
   - uid: 3804
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-67.5
       parent: 2
   - uid: 3805
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-67.5
       parent: 2
   - uid: 3807
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-67.5
       parent: 2
   - uid: 3808
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-68.5
       parent: 2
   - uid: 3809
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-68.5
       parent: 2
   - uid: 3812
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-68.5
       parent: 2
   - uid: 3813
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-67.5
       parent: 2
   - uid: 3817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-66.5
       parent: 2
   - uid: 3899
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-67.5
       parent: 2
   - uid: 3914
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-66.5
       parent: 2
   - uid: 3946
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-65.5
       parent: 2
   - uid: 3948
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-66.5
       parent: 2
   - uid: 3949
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-65.5
       parent: 2
   - uid: 3961
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-65.5
       parent: 2
   - uid: 4005
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-64.5
       parent: 2
   - uid: 4006
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-65.5
       parent: 2
   - uid: 4012
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-64.5
       parent: 2
   - uid: 4017
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-65.5
       parent: 2
   - uid: 4031
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-64.5
       parent: 2
   - uid: 4040
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-46.5
       parent: 2
   - uid: 4042
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-45.5
       parent: 2
   - uid: 4250
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-45.5
       parent: 2
   - uid: 4431
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-44.5
       parent: 2
   - uid: 4441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-44.5
       parent: 2
   - uid: 4444
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-43.5
       parent: 2
   - uid: 4446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-42.5
       parent: 2
   - uid: 4453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-52.5
       parent: 2
   - uid: 4458
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-53.5
       parent: 2
   - uid: 4461
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-53.5
       parent: 2
   - uid: 4564
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-54.5
       parent: 2
   - uid: 4565
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-55.5
       parent: 2
   - uid: 4588
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-57.5
       parent: 2
   - uid: 4589
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-58.5
       parent: 2
   - uid: 4590
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-56.5
       parent: 2
   - uid: 4591
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-57.5
       parent: 2
   - uid: 4592
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-58.5
       parent: 2
   - uid: 4593
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-59.5
       parent: 2
   - uid: 4594
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-60.5
       parent: 2
   - uid: 4595
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-61.5
       parent: 2
   - uid: 4598
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-61.5
       parent: 2
   - uid: 4611
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-62.5
       parent: 2
   - uid: 4612
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-62.5
       parent: 2
   - uid: 4613
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-62.5
       parent: 2
   - uid: 4614
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-63.5
       parent: 2
   - uid: 4615
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-63.5
       parent: 2
   - uid: 4616
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-63.5
       parent: 2
   - uid: 4620
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-64.5
       parent: 2
   - uid: 4700
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-64.5
       parent: 2
   - uid: 4701
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-41.5
       parent: 2
   - uid: 4702
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-40.5
       parent: 2
   - uid: 4703
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-39.5
       parent: 2
   - uid: 4704
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-38.5
       parent: 2
   - uid: 4705
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-37.5
       parent: 2
   - uid: 4708
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-37.5
       parent: 2
   - uid: 4796
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-36.5
       parent: 2
   - uid: 4797
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-35.5
       parent: 2
   - uid: 4843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-34.5
       parent: 2
   - uid: 4844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-34.5
       parent: 2
   - uid: 4845
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-34.5
       parent: 2
   - uid: 4846
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-34.5
       parent: 2
   - uid: 4850
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-35.5
       parent: 2
   - uid: 4851
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-34.5
       parent: 2
   - uid: 4852
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-30.5
       parent: 2
   - uid: 4854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-29.5
       parent: 2
   - uid: 4855
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-29.5
       parent: 2
   - uid: 4858
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-41.5
       parent: 2
   - uid: 4863
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-40.5
       parent: 2
   - uid: 4864
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-42.5
       parent: 2
   - uid: 4865
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,48.5
       parent: 2
   - uid: 4866
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,47.5
       parent: 2
   - uid: 4867
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,49.5
       parent: 2
   - uid: 4868
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,47.5
       parent: 2
   - uid: 4872
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,48.5
       parent: 2
   - uid: 5241
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,46.5
       parent: 2
   - uid: 5306
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,45.5
       parent: 2
   - uid: 5308
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,44.5
       parent: 2
   - uid: 5310
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,45.5
       parent: 2
   - uid: 5312
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,44.5
       parent: 2
   - uid: 6474
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,44.5
       parent: 2
   - uid: 6481
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-31.5
       parent: 2
   - uid: 6537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-30.5
       parent: 2
   - uid: 6544
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,-28.5
       parent: 2
   - uid: 6545
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,-28.5
       parent: 2
   - uid: 6547
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,-28.5
       parent: 2
   - uid: 6548
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-31.5
       parent: 2
   - uid: 6549
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-27.5
       parent: 2
   - uid: 6555
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-31.5
       parent: 2
   - uid: 6556
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-31.5
       parent: 2
   - uid: 6559
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-31.5
       parent: 2
   - uid: 6562
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-31.5
       parent: 2
   - uid: 6563
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-32.5
       parent: 2
   - uid: 6585
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-31.5
       parent: 2
   - uid: 6588
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-32.5
       parent: 2
   - uid: 6590
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-31.5
       parent: 2
   - uid: 6625
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-32.5
       parent: 2
   - uid: 6626
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-31.5
       parent: 2
   - uid: 6627
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-31.5
       parent: 2
   - uid: 6631
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-32.5
       parent: 2
   - uid: 6634
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-32.5
       parent: 2
   - uid: 6638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-33.5
       parent: 2
   - uid: 6642
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-33.5
       parent: 2
   - uid: 6650
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-38.5
       parent: 2
   - uid: 6651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-37.5
       parent: 2
   - uid: 6653
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-35.5
       parent: 2
   - uid: 6656
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-34.5
       parent: 2
   - uid: 6853
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-39.5
       parent: 2
   - uid: 6954
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-42.5
       parent: 2
   - uid: 6963
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-41.5
       parent: 2
   - uid: 6964
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-43.5
       parent: 2
   - uid: 7030
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-44.5
       parent: 2
   - uid: 7031
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-45.5
       parent: 2
   - uid: 7032
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-45.5
       parent: 2
   - uid: 7034
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-26.5
       parent: 2
   - uid: 7036
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-28.5
       parent: 2
   - uid: 7051
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-27.5
       parent: 2
   - uid: 7052
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-26.5
       parent: 2
   - uid: 7062
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-20.5
       parent: 2
   - uid: 7065
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-20.5
       parent: 2
   - uid: 7072
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,-19.5
       parent: 2
   - uid: 7073
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,-18.5
       parent: 2
   - uid: 7078
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-28.5
       parent: 2
   - uid: 7079
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-29.5
       parent: 2
   - uid: 7089
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-29.5
       parent: 2
   - uid: 7090
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-30.5
       parent: 2
   - uid: 7092
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-30.5
       parent: 2
   - uid: 7094
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-30.5
       parent: 2
   - uid: 7106
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-30.5
       parent: 2
   - uid: 7108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-29.5
       parent: 2
   - uid: 7119
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-29.5
       parent: 2
   - uid: 7129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-29.5
       parent: 2
   - uid: 7131
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-29.5
       parent: 2
   - uid: 7144
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-28.5
       parent: 2
   - uid: 7146
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-27.5
       parent: 2
   - uid: 7154
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-27.5
       parent: 2
   - uid: 8009
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,47.5
       parent: 2
   - uid: 8010
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,46.5
       parent: 2
   - uid: 8017
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,45.5
       parent: 2
   - uid: 8018
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,44.5
       parent: 2
   - uid: 8055
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,45.5
       parent: 2
   - uid: 8056
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,44.5
       parent: 2
   - uid: 8061
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,43.5
       parent: 2
   - uid: 8063
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,45.5
       parent: 2
   - uid: 8065
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,44.5
       parent: 2
   - uid: 8123
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,43.5
       parent: 2
   - uid: 8244
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,44.5
       parent: 2
   - uid: 8441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,43.5
       parent: 2
   - uid: 10031
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,46.5
       parent: 2
   - uid: 10034
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,47.5
       parent: 2
   - uid: 10035
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,46.5
       parent: 2
   - uid: 10038
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,47.5
       parent: 2
   - uid: 10040
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,46.5
       parent: 2
   - uid: 10131
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,47.5
       parent: 2
   - uid: 10153
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,46.5
       parent: 2
   - uid: 10162
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,46.5
       parent: 2
   - uid: 10163
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,46.5
       parent: 2
   - uid: 10166
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,46.5
       parent: 2
   - uid: 10374
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,36.5
       parent: 2
   - uid: 10386
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-30.5
       parent: 2
   - uid: 10389
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-15.5
       parent: 2
   - uid: 10390
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-16.5
       parent: 2
   - uid: 10391
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-15.5
       parent: 2
   - uid: 10392
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-14.5
       parent: 2
   - uid: 10393
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-12.5
       parent: 2
   - uid: 10465
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-26.5
       parent: 2
   - uid: 10469
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-26.5
       parent: 2
   - uid: 10472
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-27.5
       parent: 2
   - uid: 10473
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-27.5
       parent: 2
   - uid: 10488
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-25.5
       parent: 2
   - uid: 10490
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-24.5
       parent: 2
   - uid: 10493
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,0.5
       parent: 2
   - uid: 10494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-12.5
       parent: 2
   - uid: 10496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-20.5
       parent: 2
   - uid: 10500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-14.5
       parent: 2
   - uid: 10501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-22.5
       parent: 2
   - uid: 10503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-13.5
       parent: 2
   - uid: 10504
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-23.5
       parent: 2
   - uid: 10505
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-21.5
       parent: 2
   - uid: 10507
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-14.5
       parent: 2
   - uid: 10517
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-13.5
       parent: 2
   - uid: 10537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-12.5
       parent: 2
   - uid: 10538
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-11.5
       parent: 2
   - uid: 10539
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-11.5
       parent: 2
   - uid: 10543
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-10.5
       parent: 2
   - uid: 10545
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-10.5
       parent: 2
   - uid: 10547
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-10.5
       parent: 2
   - uid: 10548
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-9.5
       parent: 2
   - uid: 10549
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-9.5
       parent: 2
   - uid: 10550
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,-8.5
       parent: 2
   - uid: 10551
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-8.5
       parent: 2
   - uid: 10554
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-7.5
       parent: 2
   - uid: 10555
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-6.5
       parent: 2
   - uid: 10556
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-5.5
       parent: 2
   - uid: 10557
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-4.5
       parent: 2
   - uid: 10564
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 54.5,-3.5
       parent: 2
   - uid: 10565
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 54.5,-2.5
       parent: 2
   - uid: 10566
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 54.5,-1.5
       parent: 2
   - uid: 10567
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 54.5,-0.5
       parent: 2
   - uid: 10568
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-3.5
       parent: 2
   - uid: 10569
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-2.5
       parent: 2
   - uid: 10570
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-1.5
       parent: 2
   - uid: 10571
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,-0.5
       parent: 2
   - uid: 10574
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,1.5
       parent: 2
   - uid: 10578
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,2.5
       parent: 2
   - uid: 10580
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,3.5
       parent: 2
   - uid: 10582
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,3.5
       parent: 2
   - uid: 10584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,3.5
       parent: 2
   - uid: 10586
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,3.5
       parent: 2
   - uid: 10589
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,4.5
       parent: 2
   - uid: 10591
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,4.5
       parent: 2
   - uid: 10593
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,4.5
       parent: 2
   - uid: 10594
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,3.5
       parent: 2
   - uid: 10596
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,3.5
       parent: 2
   - uid: 10598
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,3.5
       parent: 2
   - uid: 10600
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,3.5
       parent: 2
   - uid: 10601
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,3.5
       parent: 2
   - uid: 10603
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,10.5
       parent: 2
   - uid: 10604
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,10.5
       parent: 2
   - uid: 10605
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,10.5
       parent: 2
   - uid: 10606
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,10.5
       parent: 2
   - uid: 10612
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,48.5
       parent: 2
   - uid: 10613
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,48.5
       parent: 2
   - uid: 10614
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,48.5
       parent: 2
   - uid: 10615
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,48.5
       parent: 2
   - uid: 10616
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,49.5
       parent: 2
   - uid: 10617
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,49.5
       parent: 2
   - uid: 10618
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,48.5
       parent: 2
   - uid: 10619
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,47.5
       parent: 2
   - uid: 10623
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,46.5
       parent: 2
   - uid: 10624
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,45.5
       parent: 2
   - uid: 10626
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,44.5
       parent: 2
   - uid: 10627
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,43.5
       parent: 2
   - uid: 10628
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,42.5
       parent: 2
   - uid: 10635
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,41.5
       parent: 2
   - uid: 10636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,40.5
       parent: 2
   - uid: 10637
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,39.5
       parent: 2
   - uid: 10641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,38.5
       parent: 2
   - uid: 10642
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,37.5
       parent: 2
   - uid: 10643
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,35.5
       parent: 2
   - uid: 10649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,35.5
       parent: 2
   - uid: 10650
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,35.5
       parent: 2
   - uid: 10651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,34.5
       parent: 2
   - uid: 10652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,34.5
       parent: 2
   - uid: 10653
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,34.5
       parent: 2
   - uid: 10655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,34.5
       parent: 2
   - uid: 10656
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,30.5
       parent: 2
   - uid: 10657
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,30.5
       parent: 2
   - uid: 10658
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,30.5
       parent: 2
   - uid: 10659
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,30.5
       parent: 2
   - uid: 10661
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,30.5
       parent: 2
   - uid: 10662
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,30.5
       parent: 2
   - uid: 10663
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,29.5
       parent: 2
   - uid: 10673
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,29.5
       parent: 2
   - uid: 10674
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,29.5
       parent: 2
   - uid: 10675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,29.5
       parent: 2
   - uid: 10676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,28.5
       parent: 2
   - uid: 10679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,27.5
       parent: 2
   - uid: 10681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,26.5
       parent: 2
   - uid: 10693
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,22.5
       parent: 2
   - uid: 10696
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,21.5
       parent: 2
   - uid: 10699
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,20.5
       parent: 2
   - uid: 10701
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,19.5
       parent: 2
   - uid: 10702
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 54.5,18.5
       parent: 2
   - uid: 10703
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 54.5,17.5
       parent: 2
   - uid: 10704
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 54.5,16.5
       parent: 2
   - uid: 10707
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,18.5
       parent: 2
   - uid: 10709
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,17.5
       parent: 2
   - uid: 10710
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,16.5
       parent: 2
   - uid: 10718
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 53.5,15.5
       parent: 2
   - uid: 10721
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 52.5,14.5
       parent: 2
   - uid: 10739
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,13.5
       parent: 2
   - uid: 10755
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,12.5
       parent: 2
   - uid: 10829
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,12.5
       parent: 2
   - uid: 11070
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,11.5
       parent: 2
   - uid: 11108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,11.5
       parent: 2
   - uid: 11111
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,10.5
       parent: 2
   - uid: 11113
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,9.5
       parent: 2
   - uid: 11661
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-40.5
       parent: 2
   - uid: 11874
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,-14.5
       parent: 2
   - uid: 11925
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,-16.5
       parent: 2
   - uid: 11928
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,-15.5
       parent: 2
   - uid: 11929
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,-15.5
       parent: 2
   - uid: 11934
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,-14.5
       parent: 2
   - uid: 11947
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,-13.5
       parent: 2
   - uid: 11948
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-13.5
       parent: 2
   - uid: 11952
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-12.5
       parent: 2
   - uid: 11957
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-11.5
       parent: 2
   - uid: 11958
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-10.5
       parent: 2
   - uid: 11960
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,-9.5
       parent: 2
   - uid: 11961
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,-8.5
       parent: 2
   - uid: 11977
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-7.5
       parent: 2
   - uid: 11978
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-6.5
       parent: 2
   - uid: 11979
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-5.5
       parent: 2
   - uid: 11980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,-4.5
       parent: 2
   - uid: 11986
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,1.5
       parent: 2
   - uid: 11987
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,2.5
       parent: 2
   - uid: 11988
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,3.5
       parent: 2
   - uid: 11989
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,4.5
       parent: 2
   - uid: 11990
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,5.5
       parent: 2
   - uid: 11991
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -86.5,6.5
       parent: 2
   - uid: 12130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,44.5
       parent: 2
   - uid: 12174
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,15.5
       parent: 2
   - uid: 12222
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,7.5
       parent: 2
   - uid: 12225
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,12.5
       parent: 2
   - uid: 12226
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,13.5
       parent: 2
   - uid: 12227
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,14.5
       parent: 2
   - uid: 12228
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,8.5
       parent: 2
   - uid: 12233
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,11.5
       parent: 2
   - uid: 12258
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -85.5,9.5
       parent: 2
   - uid: 12297
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,10.5
       parent: 2
   - uid: 12382
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-52.5
       parent: 2
   - uid: 12383
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-52.5
       parent: 2
   - uid: 12384
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-43.5
       parent: 2
   - uid: 12385
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-39.5
       parent: 2
   - uid: 12432
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,45.5
       parent: 2
   - uid: 12433
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,45.5
       parent: 2
   - uid: 12435
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,45.5
       parent: 2
   - uid: 12437
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,45.5
       parent: 2
   - uid: 12448
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,44.5
       parent: 2
   - uid: 12506
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,43.5
       parent: 2
   - uid: 12507
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,42.5
       parent: 2
   - uid: 12508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,41.5
       parent: 2
   - uid: 12509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,40.5
       parent: 2
   - uid: 12510
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,39.5
       parent: 2
   - uid: 12515
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,40.5
       parent: 2
   - uid: 12516
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,39.5
       parent: 2
   - uid: 12517
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,38.5
       parent: 2
   - uid: 12521
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,39.5
       parent: 2
   - uid: 12522
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,38.5
       parent: 2
   - uid: 12526
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,39.5
       parent: 2
   - uid: 12527
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,38.5
       parent: 2
   - uid: 12528
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,37.5
       parent: 2
   - uid: 12533
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,37.5
       parent: 2
   - uid: 12534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,38.5
       parent: 2
   - uid: 12537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,37.5
       parent: 2
   - uid: 12538
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,38.5
       parent: 2
   - uid: 12545
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,35.5
       parent: 2
   - uid: 12546
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,36.5
       parent: 2
@@ -107405,15 +100344,11 @@ entities:
   entities:
   - uid: 8187
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,47.5
       parent: 2
   - uid: 8635
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,44.5
       parent: 2
@@ -107421,8 +100356,6 @@ entities:
   entities:
   - uid: 6938
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-41.5
       parent: 2
@@ -107430,6196 +100363,4426 @@ entities:
   entities:
   - uid: 211
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,1.5
       parent: 2
   - uid: 524
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-29.5
       parent: 2
   - uid: 591
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,11.5
       parent: 2
   - uid: 592
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,12.5
       parent: 2
   - uid: 593
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-28.5
       parent: 2
   - uid: 595
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,13.5
       parent: 2
   - uid: 596
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,13.5
       parent: 2
   - uid: 597
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,12.5
       parent: 2
   - uid: 598
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,11.5
       parent: 2
   - uid: 656
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,17.5
       parent: 2
   - uid: 700
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-30.5
       parent: 2
   - uid: 701
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-15.5
       parent: 2
   - uid: 720
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-26.5
       parent: 2
   - uid: 811
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,12.5
       parent: 2
   - uid: 812
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,13.5
       parent: 2
   - uid: 813
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,12.5
       parent: 2
   - uid: 815
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,13.5
       parent: 2
   - uid: 816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,12.5
       parent: 2
   - uid: 817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,11.5
       parent: 2
   - uid: 823
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,8.5
       parent: 2
   - uid: 824
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,8.5
       parent: 2
   - uid: 829
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,17.5
       parent: 2
   - uid: 830
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,17.5
       parent: 2
   - uid: 831
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,16.5
       parent: 2
   - uid: 832
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,16.5
       parent: 2
   - uid: 843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,5.5
       parent: 2
   - uid: 848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,5.5
       parent: 2
   - uid: 863
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-29.5
       parent: 2
   - uid: 886
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-29.5
       parent: 2
   - uid: 1049
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-28.5
       parent: 2
   - uid: 1144
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,4.5
       parent: 2
   - uid: 1145
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,4.5
       parent: 2
   - uid: 1147
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,3.5
       parent: 2
   - uid: 1150
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,2.5
       parent: 2
   - uid: 1198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,-12.5
       parent: 2
   - uid: 1203
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,-7.5
       parent: 2
   - uid: 1205
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,-12.5
       parent: 2
   - uid: 1214
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-27.5
       parent: 2
   - uid: 1261
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-24.5
       parent: 2
   - uid: 1263
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-24.5
       parent: 2
   - uid: 1277
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-23.5
       parent: 2
   - uid: 1278
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-22.5
       parent: 2
   - uid: 1280
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-22.5
       parent: 2
   - uid: 1285
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-22.5
       parent: 2
   - uid: 1290
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-21.5
       parent: 2
   - uid: 1297
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-24.5
       parent: 2
   - uid: 1298
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,31.5
       parent: 2
   - uid: 1300
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,5.5
       parent: 2
   - uid: 1302
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,5.5
       parent: 2
   - uid: 1303
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,4.5
       parent: 2
   - uid: 1358
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-22.5
       parent: 2
   - uid: 1359
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-22.5
       parent: 2
   - uid: 1363
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-23.5
       parent: 2
   - uid: 1375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-26.5
       parent: 2
   - uid: 1442
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-26.5
       parent: 2
   - uid: 1469
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,-26.5
       parent: 2
   - uid: 1478
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-21.5
       parent: 2
   - uid: 1490
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-24.5
       parent: 2
   - uid: 1491
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-25.5
       parent: 2
   - uid: 1508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-29.5
       parent: 2
   - uid: 1520
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-25.5
       parent: 2
   - uid: 1560
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-26.5
       parent: 2
   - uid: 1630
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-27.5
       parent: 2
   - uid: 1632
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -44.5,7.5
       parent: 2
   - uid: 1637
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-0.5
       parent: 2
   - uid: 1638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,-1.5
       parent: 2
   - uid: 1641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-1.5
       parent: 2
   - uid: 1642
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,-0.5
       parent: 2
   - uid: 1644
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-1.5
       parent: 2
   - uid: 1645
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,-0.5
       parent: 2
   - uid: 1648
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-0.5
       parent: 2
   - uid: 1671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,6.5
       parent: 2
   - uid: 1672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,7.5
       parent: 2
   - uid: 1673
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,7.5
       parent: 2
   - uid: 1674
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,7.5
       parent: 2
   - uid: 1677
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,7.5
       parent: 2
   - uid: 1679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -38.5,7.5
       parent: 2
   - uid: 1681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -39.5,7.5
       parent: 2
   - uid: 1683
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -40.5,7.5
       parent: 2
   - uid: 1687
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,1.5
       parent: 2
   - uid: 1689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,7.5
       parent: 2
   - uid: 1691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -42.5,7.5
       parent: 2
   - uid: 1693
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,7.5
       parent: 2
   - uid: 1696
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,-0.5
       parent: 2
   - uid: 1699
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,-0.5
       parent: 2
   - uid: 1704
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-0.5
       parent: 2
   - uid: 1712
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-8.5
       parent: 2
   - uid: 1717
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,7.5
       parent: 2
   - uid: 1718
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,7.5
       parent: 2
   - uid: 1719
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -47.5,7.5
       parent: 2
   - uid: 1720
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,7.5
       parent: 2
   - uid: 1721
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,6.5
       parent: 2
   - uid: 1724
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,2.5
       parent: 2
   - uid: 1725
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-26.5
       parent: 2
   - uid: 1726
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,2.5
       parent: 2
   - uid: 1728
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-27.5
       parent: 2
   - uid: 1761
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,-11.5
       parent: 2
   - uid: 1763
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-12.5
       parent: 2
   - uid: 1764
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-12.5
       parent: 2
   - uid: 1765
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-5.5
       parent: 2
   - uid: 1766
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-4.5
       parent: 2
   - uid: 1767
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-3.5
       parent: 2
   - uid: 1768
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-4.5
       parent: 2
   - uid: 1769
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-5.5
       parent: 2
   - uid: 1770
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-6.5
       parent: 2
   - uid: 1771
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-3.5
       parent: 2
   - uid: 1774
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-6.5
       parent: 2
   - uid: 1775
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,-3.5
       parent: 2
   - uid: 1778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,-6.5
       parent: 2
   - uid: 1779
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,-7.5
       parent: 2
   - uid: 1796
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-26.5
       parent: 2
   - uid: 1798
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-28.5
       parent: 2
   - uid: 1816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-25.5
       parent: 2
   - uid: 1818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-29.5
       parent: 2
   - uid: 1820
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-9.5
       parent: 2
   - uid: 1822
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-21.5
       parent: 2
   - uid: 1823
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,-21.5
       parent: 2
   - uid: 1840
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,-25.5
       parent: 2
   - uid: 1856
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-7.5
       parent: 2
   - uid: 1857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-8.5
       parent: 2
   - uid: 1870
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-27.5
       parent: 2
   - uid: 1871
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-28.5
       parent: 2
   - uid: 1873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-27.5
       parent: 2
   - uid: 1874
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,5.5
       parent: 2
   - uid: 1918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -20.5,-29.5
       parent: 2
   - uid: 1936
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-30.5
       parent: 2
   - uid: 1971
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-1.5
       parent: 2
   - uid: 1973
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-1.5
       parent: 2
   - uid: 2004
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-10.5
       parent: 2
   - uid: 2042
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-7.5
       parent: 2
   - uid: 2046
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-8.5
       parent: 2
   - uid: 2100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-29.5
       parent: 2
   - uid: 2104
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-7.5
       parent: 2
   - uid: 2112
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-8.5
       parent: 2
   - uid: 2113
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-26.5
       parent: 2
   - uid: 2115
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-29.5
       parent: 2
   - uid: 2121
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-12.5
       parent: 2
   - uid: 2122
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-11.5
       parent: 2
   - uid: 2123
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,6.5
       parent: 2
   - uid: 2129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-28.5
       parent: 2
   - uid: 2130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-28.5
       parent: 2
   - uid: 2133
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-22.5
       parent: 2
   - uid: 2134
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-26.5
       parent: 2
   - uid: 2167
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-21.5
       parent: 2
   - uid: 2322
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-24.5
       parent: 2
   - uid: 2323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-23.5
       parent: 2
   - uid: 2324
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-23.5
       parent: 2
   - uid: 2325
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-29.5
       parent: 2
   - uid: 2331
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-30.5
       parent: 2
   - uid: 2332
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-29.5
       parent: 2
   - uid: 2333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-29.5
       parent: 2
   - uid: 2367
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-28.5
       parent: 2
   - uid: 2368
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-29.5
       parent: 2
   - uid: 2372
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-27.5
       parent: 2
   - uid: 2400
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-30.5
       parent: 2
   - uid: 2403
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-28.5
       parent: 2
   - uid: 2404
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-29.5
       parent: 2
   - uid: 2405
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-30.5
       parent: 2
   - uid: 2408
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-28.5
       parent: 2
   - uid: 2409
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-29.5
       parent: 2
   - uid: 2410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-30.5
       parent: 2
   - uid: 2413
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-30.5
       parent: 2
   - uid: 2418
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-31.5
       parent: 2
   - uid: 2421
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-29.5
       parent: 2
   - uid: 2521
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,4.5
       parent: 2
   - uid: 2652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-23.5
       parent: 2
   - uid: 2751
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-33.5
       parent: 2
   - uid: 2752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-34.5
       parent: 2
   - uid: 2753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-33.5
       parent: 2
   - uid: 2754
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-34.5
       parent: 2
   - uid: 2757
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-33.5
       parent: 2
   - uid: 2759
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-33.5
       parent: 2
   - uid: 2762
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-32.5
       parent: 2
   - uid: 2763
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-32.5
       parent: 2
   - uid: 2773
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,29.5
       parent: 2
   - uid: 2801
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-17.5
       parent: 2
   - uid: 2822
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,29.5
       parent: 2
   - uid: 2826
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,31.5
       parent: 2
   - uid: 2827
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,30.5
       parent: 2
   - uid: 3001
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-31.5
       parent: 2
   - uid: 3168
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,39.5
       parent: 2
   - uid: 3250
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,36.5
       parent: 2
   - uid: 3265
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,42.5
       parent: 2
   - uid: 3291
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,30.5
       parent: 2
   - uid: 3297
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,37.5
       parent: 2
   - uid: 3319
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,41.5
       parent: 2
   - uid: 3323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,31.5
       parent: 2
   - uid: 3386
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,30.5
       parent: 2
   - uid: 3494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,41.5
       parent: 2
   - uid: 3503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,32.5
       parent: 2
   - uid: 3571
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,37.5
       parent: 2
   - uid: 3572
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,36.5
       parent: 2
   - uid: 3584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,0.5
       parent: 2
   - uid: 5881
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-0.5
       parent: 2
   - uid: 6528
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,2.5
       parent: 2
   - uid: 7161
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-13.5
       parent: 2
   - uid: 7993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-11.5
       parent: 2
   - uid: 8057
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-23.5
       parent: 2
   - uid: 8068
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-23.5
       parent: 2
   - uid: 8073
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-23.5
       parent: 2
   - uid: 8098
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-20.5
       parent: 2
   - uid: 8838
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,27.5
       parent: 2
   - uid: 8842
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,27.5
       parent: 2
   - uid: 8843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,27.5
       parent: 2
   - uid: 8844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,29.5
       parent: 2
   - uid: 8845
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,28.5
       parent: 2
   - uid: 8846
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,26.5
       parent: 2
   - uid: 8847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,26.5
       parent: 2
   - uid: 8848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,26.5
       parent: 2
   - uid: 8849
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,26.5
       parent: 2
   - uid: 8854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,34.5
       parent: 2
   - uid: 8859
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,40.5
       parent: 2
   - uid: 8860
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,40.5
       parent: 2
   - uid: 8861
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,40.5
       parent: 2
   - uid: 8862
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,41.5
       parent: 2
   - uid: 8863
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,41.5
       parent: 2
   - uid: 8873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,13.5
       parent: 2
   - uid: 8874
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,16.5
       parent: 2
   - uid: 8875
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,16.5
       parent: 2
   - uid: 8876
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,29.5
       parent: 2
   - uid: 8878
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,31.5
       parent: 2
   - uid: 8879
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,16.5
       parent: 2
   - uid: 8992
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,13.5
       parent: 2
   - uid: 8993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,29.5
       parent: 2
   - uid: 9036
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,16.5
       parent: 2
   - uid: 9037
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,13.5
       parent: 2
   - uid: 9041
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,12.5
       parent: 2
   - uid: 9071
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,30.5
       parent: 2
   - uid: 9159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,5.5
       parent: 2
   - uid: 9160
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,5.5
       parent: 2
   - uid: 9165
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,1.5
       parent: 2
   - uid: 9168
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,2.5
       parent: 2
   - uid: 9169
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,4.5
       parent: 2
   - uid: 9171
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,1.5
       parent: 2
   - uid: 9172
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,3.5
       parent: 2
   - uid: 9173
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,2.5
       parent: 2
   - uid: 9174
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,2.5
       parent: 2
   - uid: 9176
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,0.5
       parent: 2
   - uid: 9178
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,2.5
       parent: 2
   - uid: 9179
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,5.5
       parent: 2
   - uid: 9180
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,1.5
       parent: 2
   - uid: 9181
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,3.5
       parent: 2
   - uid: 9182
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,0.5
       parent: 2
   - uid: 9183
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,1.5
       parent: 2
   - uid: 9184
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,0.5
       parent: 2
   - uid: 9185
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,0.5
       parent: 2
   - uid: 9186
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -49.5,-0.5
       parent: 2
   - uid: 9187
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -48.5,-1.5
       parent: 2
   - uid: 9188
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -50.5,-0.5
       parent: 2
   - uid: 9189
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,0.5
       parent: 2
   - uid: 9190
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-0.5
       parent: 2
   - uid: 9192
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,1.5
       parent: 2
   - uid: 9193
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,0.5
       parent: 2
   - uid: 9194
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,1.5
       parent: 2
   - uid: 9195
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,0.5
       parent: 2
   - uid: 9196
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-0.5
       parent: 2
   - uid: 9197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-1.5
       parent: 2
   - uid: 9198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-1.5
       parent: 2
   - uid: 9199
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-1.5
       parent: 2
   - uid: 9201
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-2.5
       parent: 2
   - uid: 9202
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-2.5
       parent: 2
   - uid: 9203
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-2.5
       parent: 2
   - uid: 9204
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-3.5
       parent: 2
   - uid: 9207
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-7.5
       parent: 2
   - uid: 9209
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-3.5
       parent: 2
   - uid: 9210
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-4.5
       parent: 2
   - uid: 9212
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-4.5
       parent: 2
   - uid: 9216
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,13.5
       parent: 2
   - uid: 9218
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-6.5
       parent: 2
   - uid: 9219
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-7.5
       parent: 2
   - uid: 9221
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-7.5
       parent: 2
   - uid: 9223
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,5.5
       parent: 2
   - uid: 9224
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,4.5
       parent: 2
   - uid: 9225
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,6.5
       parent: 2
   - uid: 9226
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,6.5
       parent: 2
   - uid: 9227
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,6.5
       parent: 2
   - uid: 9230
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,6.5
       parent: 2
   - uid: 9240
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,3.5
       parent: 2
   - uid: 9241
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,4.5
       parent: 2
   - uid: 9243
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,8.5
       parent: 2
   - uid: 9244
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,9.5
       parent: 2
   - uid: 9245
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,8.5
       parent: 2
   - uid: 9246
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,9.5
       parent: 2
   - uid: 9247
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,8.5
       parent: 2
   - uid: 9248
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,9.5
       parent: 2
   - uid: 9249
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,9.5
       parent: 2
   - uid: 9251
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,9.5
       parent: 2
   - uid: 9252
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,10.5
       parent: 2
   - uid: 9253
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,9.5
       parent: 2
   - uid: 9254
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,10.5
       parent: 2
   - uid: 9261
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,11.5
       parent: 2
   - uid: 9262
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,12.5
       parent: 2
   - uid: 9263
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,11.5
       parent: 2
   - uid: 9264
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,12.5
       parent: 2
   - uid: 9272
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,11.5
       parent: 2
   - uid: 9273
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -41.5,8.5
       parent: 2
   - uid: 9275
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,14.5
       parent: 2
   - uid: 9276
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,8.5
       parent: 2
   - uid: 9277
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,8.5
       parent: 2
   - uid: 9278
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,9.5
       parent: 2
   - uid: 9279
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,8.5
       parent: 2
   - uid: 9280
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,9.5
       parent: 2
   - uid: 9282
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,10.5
       parent: 2
   - uid: 9283
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,11.5
       parent: 2
   - uid: 9284
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,10.5
       parent: 2
   - uid: 9285
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,11.5
       parent: 2
   - uid: 9286
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -37.5,12.5
       parent: 2
   - uid: 9287
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,13.5
       parent: 2
   - uid: 9288
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,12.5
       parent: 2
   - uid: 9289
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,12.5
       parent: 2
   - uid: 9290
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,12.5
       parent: 2
   - uid: 9291
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,11.5
       parent: 2
   - uid: 9294
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,9.5
       parent: 2
   - uid: 9295
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,8.5
       parent: 2
   - uid: 9296
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,10.5
       parent: 2
   - uid: 9307
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,32.5
       parent: 2
   - uid: 9313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,15.5
       parent: 2
   - uid: 9314
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,15.5
       parent: 2
   - uid: 9315
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,16.5
       parent: 2
   - uid: 9316
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,14.5
       parent: 2
   - uid: 9318
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,15.5
       parent: 2
   - uid: 9319
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,16.5
       parent: 2
   - uid: 9321
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,16.5
       parent: 2
   - uid: 9325
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,13.5
       parent: 2
   - uid: 9326
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,12.5
       parent: 2
   - uid: 9333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-5.5
       parent: 2
   - uid: 9338
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-19.5
       parent: 2
   - uid: 9388
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-23.5
       parent: 2
   - uid: 9390
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-20.5
       parent: 2
   - uid: 9391
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-20.5
       parent: 2
   - uid: 9392
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-20.5
       parent: 2
   - uid: 9398
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-18.5
       parent: 2
   - uid: 9399
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-17.5
       parent: 2
   - uid: 9400
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-16.5
       parent: 2
   - uid: 9404
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-16.5
       parent: 2
   - uid: 9410
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-21.5
       parent: 2
   - uid: 9411
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-20.5
       parent: 2
   - uid: 9412
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-19.5
       parent: 2
   - uid: 9413
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-18.5
       parent: 2
   - uid: 9416
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-24.5
       parent: 2
   - uid: 9417
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-25.5
       parent: 2
   - uid: 9418
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-26.5
       parent: 2
   - uid: 9419
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-24.5
       parent: 2
   - uid: 9420
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-25.5
       parent: 2
   - uid: 9421
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-26.5
       parent: 2
   - uid: 9430
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-27.5
       parent: 2
   - uid: 9438
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-27.5
       parent: 2
   - uid: 9439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-26.5
       parent: 2
   - uid: 9441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-24.5
       parent: 2
   - uid: 9444
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-28.5
       parent: 2
   - uid: 9445
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-27.5
       parent: 2
   - uid: 9446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-26.5
       parent: 2
   - uid: 9447
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-25.5
       parent: 2
   - uid: 9448
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-24.5
       parent: 2
   - uid: 9451
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-28.5
       parent: 2
   - uid: 9452
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-27.5
       parent: 2
   - uid: 9454
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-25.5
       parent: 2
   - uid: 9455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-24.5
       parent: 2
   - uid: 9459
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-27.5
       parent: 2
   - uid: 9460
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-26.5
       parent: 2
   - uid: 9461
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-25.5
       parent: 2
   - uid: 9462
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-24.5
       parent: 2
   - uid: 9466
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-27.5
       parent: 2
   - uid: 9467
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-26.5
       parent: 2
   - uid: 9468
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-25.5
       parent: 2
   - uid: 9469
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-24.5
       parent: 2
   - uid: 9472
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-27.5
       parent: 2
   - uid: 9473
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-26.5
       parent: 2
   - uid: 9474
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-25.5
       parent: 2
   - uid: 9475
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-24.5
       parent: 2
   - uid: 9478
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-27.5
       parent: 2
   - uid: 9479
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-26.5
       parent: 2
   - uid: 9480
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-25.5
       parent: 2
   - uid: 9481
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-24.5
       parent: 2
   - uid: 9485
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-26.5
       parent: 2
   - uid: 9486
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-25.5
       parent: 2
   - uid: 9487
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-24.5
       parent: 2
   - uid: 9488
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-23.5
       parent: 2
   - uid: 9489
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-23.5
       parent: 2
   - uid: 9494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-22.5
       parent: 2
   - uid: 9495
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-21.5
       parent: 2
   - uid: 9502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-22.5
       parent: 2
   - uid: 9504
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-20.5
       parent: 2
   - uid: 9505
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-19.5
       parent: 2
   - uid: 9506
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-18.5
       parent: 2
   - uid: 9508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,0.5
       parent: 2
   - uid: 9509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,5.5
       parent: 2
   - uid: 9527
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-26.5
       parent: 2
   - uid: 9529
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-25.5
       parent: 2
   - uid: 9530
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-24.5
       parent: 2
   - uid: 9531
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-23.5
       parent: 2
   - uid: 9532
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-22.5
       parent: 2
   - uid: 9533
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-25.5
       parent: 2
   - uid: 9534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-24.5
       parent: 2
   - uid: 9535
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-23.5
       parent: 2
   - uid: 9536
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-22.5
       parent: 2
   - uid: 9537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-25.5
       parent: 2
   - uid: 9539
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-23.5
       parent: 2
   - uid: 9540
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-22.5
       parent: 2
   - uid: 9541
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-23.5
       parent: 2
   - uid: 9542
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-22.5
       parent: 2
   - uid: 9543
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-23.5
       parent: 2
   - uid: 9544
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-22.5
       parent: 2
   - uid: 9545
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-21.5
       parent: 2
   - uid: 9546
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-20.5
       parent: 2
   - uid: 9547
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-19.5
       parent: 2
   - uid: 9548
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-18.5
       parent: 2
   - uid: 9549
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-21.5
       parent: 2
   - uid: 9550
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-20.5
       parent: 2
   - uid: 9551
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-19.5
       parent: 2
   - uid: 9552
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-18.5
       parent: 2
   - uid: 9553
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-21.5
       parent: 2
   - uid: 9554
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-20.5
       parent: 2
   - uid: 9556
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-18.5
       parent: 2
   - uid: 9557
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-21.5
       parent: 2
   - uid: 9558
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-20.5
       parent: 2
   - uid: 9559
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-19.5
       parent: 2
   - uid: 9560
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-18.5
       parent: 2
   - uid: 9565
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-16.5
       parent: 2
   - uid: 9566
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-17.5
       parent: 2
   - uid: 9567
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-16.5
       parent: 2
   - uid: 9568
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-17.5
       parent: 2
   - uid: 9569
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-16.5
       parent: 2
   - uid: 9570
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-17.5
       parent: 2
   - uid: 9571
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-16.5
       parent: 2
   - uid: 9572
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-17.5
       parent: 2
   - uid: 9573
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-16.5
       parent: 2
   - uid: 9575
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-16.5
       parent: 2
   - uid: 9577
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-16.5
       parent: 2
   - uid: 9578
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-17.5
       parent: 2
   - uid: 9579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-16.5
       parent: 2
   - uid: 9580
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-17.5
       parent: 2
   - uid: 9581
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-16.5
       parent: 2
   - uid: 9582
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-16.5
       parent: 2
   - uid: 9584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-15.5
       parent: 2
   - uid: 9585
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-15.5
       parent: 2
   - uid: 9586
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-14.5
       parent: 2
   - uid: 9587
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-15.5
       parent: 2
   - uid: 9589
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-15.5
       parent: 2
   - uid: 9590
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-14.5
       parent: 2
   - uid: 9591
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-15.5
       parent: 2
   - uid: 9592
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-14.5
       parent: 2
   - uid: 9593
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-15.5
       parent: 2
   - uid: 9594
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-14.5
       parent: 2
   - uid: 9595
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-15.5
       parent: 2
   - uid: 9596
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-14.5
       parent: 2
   - uid: 9597
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-15.5
       parent: 2
   - uid: 9598
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-14.5
       parent: 2
   - uid: 9599
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-15.5
       parent: 2
   - uid: 9600
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-14.5
       parent: 2
   - uid: 9665
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,16.5
       parent: 2
   - uid: 9667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,-10.5
       parent: 2
   - uid: 9668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-10.5
       parent: 2
   - uid: 9669
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,-11.5
       parent: 2
   - uid: 9671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-11.5
       parent: 2
   - uid: 9672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-9.5
       parent: 2
   - uid: 9673
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-10.5
       parent: 2
   - uid: 9674
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-9.5
       parent: 2
   - uid: 9675
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-10.5
       parent: 2
   - uid: 9676
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-9.5
       parent: 2
   - uid: 9677
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-10.5
       parent: 2
   - uid: 9698
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-13.5
       parent: 2
   - uid: 9699
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-12.5
       parent: 2
   - uid: 9700
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-13.5
       parent: 2
   - uid: 9701
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-12.5
       parent: 2
   - uid: 9702
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,-11.5
       parent: 2
   - uid: 9703
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-13.5
       parent: 2
   - uid: 9704
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-12.5
       parent: 2
   - uid: 9705
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-11.5
       parent: 2
   - uid: 9706
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-13.5
       parent: 2
   - uid: 9707
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-12.5
       parent: 2
   - uid: 9708
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,33.5
       parent: 2
   - uid: 9935
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,10.5
       parent: 2
   - uid: 10263
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,44.5
       parent: 2
   - uid: 10264
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,44.5
       parent: 2
   - uid: 10277
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-4.5
       parent: 2
   - uid: 10366
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,0.5
       parent: 2
   - uid: 10370
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,30.5
       parent: 2
   - uid: 10375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,29.5
       parent: 2
   - uid: 10395
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,38.5
       parent: 2
   - uid: 10464
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,32.5
       parent: 2
   - uid: 10492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-1.5
       parent: 2
   - uid: 10495
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,34.5
       parent: 2
   - uid: 10498
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,43.5
       parent: 2
   - uid: 10512
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,41.5
       parent: 2
   - uid: 10513
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,40.5
       parent: 2
   - uid: 10515
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,41.5
       parent: 2
   - uid: 10516
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,40.5
       parent: 2
   - uid: 10523
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,39.5
       parent: 2
   - uid: 10524
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,38.5
       parent: 2
   - uid: 10525
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,37.5
       parent: 2
   - uid: 10526
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,36.5
       parent: 2
   - uid: 10528
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,39.5
       parent: 2
   - uid: 10529
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,38.5
       parent: 2
   - uid: 10530
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,37.5
       parent: 2
   - uid: 10531
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,36.5
       parent: 2
   - uid: 10733
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,4.5
       parent: 2
   - uid: 10734
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,5.5
       parent: 2
   - uid: 10758
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,14.5
       parent: 2
   - uid: 10776
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,14.5
       parent: 2
   - uid: 10817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,15.5
       parent: 2
   - uid: 11036
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,3.5
       parent: 2
   - uid: 11043
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,15.5
       parent: 2
   - uid: 11044
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,16.5
       parent: 2
   - uid: 11045
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,16.5
       parent: 2
   - uid: 11046
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,14.5
       parent: 2
   - uid: 11047
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,15.5
       parent: 2
   - uid: 11048
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,16.5
       parent: 2
   - uid: 11055
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,10.5
       parent: 2
   - uid: 11061
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,13.5
       parent: 2
   - uid: 11062
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,13.5
       parent: 2
   - uid: 11065
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,17.5
       parent: 2
   - uid: 11066
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,17.5
       parent: 2
   - uid: 11067
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,17.5
       parent: 2
   - uid: 11068
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,18.5
       parent: 2
   - uid: 11119
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,35.5
       parent: 2
   - uid: 11120
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,35.5
       parent: 2
   - uid: 11121
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,35.5
       parent: 2
   - uid: 11122
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,35.5
       parent: 2
   - uid: 11123
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,35.5
       parent: 2
   - uid: 11124
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,11.5
       parent: 2
   - uid: 11125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,34.5
       parent: 2
   - uid: 11126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,34.5
       parent: 2
   - uid: 11127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,4.5
       parent: 2
   - uid: 11128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,33.5
       parent: 2
   - uid: 11638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,4.5
       parent: 2
   - uid: 11640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,32.5
       parent: 2
   - uid: 11663
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,4.5
       parent: 2
   - uid: 11733
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,28.5
       parent: 2
   - uid: 11734
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,28.5
       parent: 2
   - uid: 11738
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,32.5
       parent: 2
   - uid: 11739
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,32.5
       parent: 2
   - uid: 11742
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,3.5
       parent: 2
   - uid: 11747
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,3.5
       parent: 2
   - uid: 11749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,0.5
       parent: 2
   - uid: 11752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,2.5
       parent: 2
   - uid: 11755
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,-4.5
       parent: 2
   - uid: 11756
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,29.5
       parent: 2
   - uid: 11757
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,29.5
       parent: 2
   - uid: 11758
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,29.5
       parent: 2
   - uid: 11761
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,29.5
       parent: 2
   - uid: 11764
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,28.5
       parent: 2
   - uid: 11765
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,28.5
       parent: 2
   - uid: 11768
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,28.5
       parent: 2
   - uid: 11771
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-22.5
       parent: 2
   - uid: 11781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-5.5
       parent: 2
   - uid: 11783
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,-4.5
       parent: 2
   - uid: 11786
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-5.5
       parent: 2
   - uid: 11787
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,42.5
       parent: 2
   - uid: 11789
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,36.5
       parent: 2
   - uid: 11790
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,30.5
       parent: 2
   - uid: 11792
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-4.5
       parent: 2
   - uid: 11795
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,30.5
       parent: 2
   - uid: 11803
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,38.5
       parent: 2
   - uid: 11805
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,30.5
       parent: 2
   - uid: 11812
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,37.5
       parent: 2
   - uid: 11815
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,33.5
       parent: 2
   - uid: 11816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,33.5
       parent: 2
   - uid: 11824
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-9.5
       parent: 2
   - uid: 11827
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-11.5
       parent: 2
   - uid: 11831
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-10.5
       parent: 2
   - uid: 11832
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-13.5
       parent: 2
   - uid: 11833
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-11.5
       parent: 2
   - uid: 11834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-11.5
       parent: 2
   - uid: 11835
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-11.5
       parent: 2
   - uid: 11836
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-11.5
       parent: 2
   - uid: 11837
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-11.5
       parent: 2
   - uid: 11838
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-11.5
       parent: 2
   - uid: 11839
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-12.5
       parent: 2
   - uid: 11840
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-12.5
       parent: 2
   - uid: 11841
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,6.5
       parent: 2
   - uid: 11843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-14.5
       parent: 2
   - uid: 11845
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-14.5
       parent: 2
   - uid: 11846
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-13.5
       parent: 2
   - uid: 11847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-14.5
       parent: 2
   - uid: 11848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-15.5
       parent: 2
   - uid: 11849
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-15.5
       parent: 2
   - uid: 11855
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-10.5
       parent: 2
   - uid: 11856
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-9.5
       parent: 2
   - uid: 11857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-10.5
       parent: 2
   - uid: 11858
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-9.5
       parent: 2
   - uid: 11859
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-8.5
       parent: 2
   - uid: 11860
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-7.5
       parent: 2
   - uid: 11861
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-7.5
       parent: 2
   - uid: 11862
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-10.5
       parent: 2
   - uid: 11863
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-9.5
       parent: 2
   - uid: 11864
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-10.5
       parent: 2
   - uid: 11865
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-9.5
       parent: 2
   - uid: 11866
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-10.5
       parent: 2
   - uid: 11869
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,0.5
       parent: 2
   - uid: 11871
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-6.5
       parent: 2
   - uid: 11873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-5.5
       parent: 2
   - uid: 11875
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-0.5
       parent: 2
   - uid: 11877
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-5.5
       parent: 2
   - uid: 11878
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-4.5
       parent: 2
   - uid: 11882
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-4.5
       parent: 2
   - uid: 11883
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-3.5
       parent: 2
   - uid: 11884
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-2.5
       parent: 2
   - uid: 11890
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-3.5
       parent: 2
   - uid: 11891
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-2.5
       parent: 2
   - uid: 11892
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,6.5
       parent: 2
   - uid: 11893
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-2.5
       parent: 2
   - uid: 11896
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,5.5
       parent: 2
   - uid: 11900
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-1.5
       parent: 2
   - uid: 11901
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-0.5
       parent: 2
   - uid: 11902
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-0.5
       parent: 2
   - uid: 11903
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-2.5
       parent: 2
   - uid: 11904
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,6.5
       parent: 2
   - uid: 11905
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-1.5
       parent: 2
   - uid: 11906
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-2.5
       parent: 2
   - uid: 11907
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,6.5
       parent: 2
   - uid: 11908
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-4.5
       parent: 2
   - uid: 11909
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-4.5
       parent: 2
   - uid: 11913
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,-8.5
       parent: 2
   - uid: 11915
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-2.5
       parent: 2
   - uid: 11917
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,-3.5
       parent: 2
   - uid: 11919
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,0.5
       parent: 2
   - uid: 11922
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,-0.5
       parent: 2
   - uid: 11931
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,-15.5
       parent: 2
   - uid: 11932
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-15.5
       parent: 2
   - uid: 11933
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-15.5
       parent: 2
   - uid: 11938
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,-14.5
       parent: 2
   - uid: 11939
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,-14.5
       parent: 2
   - uid: 11940
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,-14.5
       parent: 2
   - uid: 11941
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,-14.5
       parent: 2
   - uid: 11942
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-14.5
       parent: 2
   - uid: 11953
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,-11.5
       parent: 2
   - uid: 11967
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,37.5
       parent: 2
   - uid: 11985
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,5.5
       parent: 2
   - uid: 11993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-5.5
       parent: 2
   - uid: 11994
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,44.5
       parent: 2
   - uid: 12007
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-4.5
       parent: 2
   - uid: 12027
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,-1.5
       parent: 2
   - uid: 12034
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,1.5
       parent: 2
   - uid: 12044
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,-5.5
       parent: 2
   - uid: 12086
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,1.5
       parent: 2
   - uid: 12087
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,8.5
       parent: 2
   - uid: 12088
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,1.5
       parent: 2
   - uid: 12089
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,2.5
       parent: 2
   - uid: 12090
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,1.5
       parent: 2
   - uid: 12091
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,2.5
       parent: 2
   - uid: 12092
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,1.5
       parent: 2
   - uid: 12093
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,2.5
       parent: 2
   - uid: 12094
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,1.5
       parent: 2
   - uid: 12095
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,2.5
       parent: 2
   - uid: 12096
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,1.5
       parent: 2
   - uid: 12097
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,2.5
       parent: 2
   - uid: 12098
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,1.5
       parent: 2
   - uid: 12099
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,2.5
       parent: 2
   - uid: 12100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,1.5
       parent: 2
   - uid: 12101
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,2.5
       parent: 2
   - uid: 12102
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,1.5
       parent: 2
   - uid: 12107
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,4.5
       parent: 2
   - uid: 12108
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,1.5
       parent: 2
   - uid: 12109
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,2.5
       parent: 2
   - uid: 12110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,0.5
       parent: 2
   - uid: 12112
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,3.5
       parent: 2
   - uid: 12113
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,5.5
       parent: 2
   - uid: 12114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,5.5
       parent: 2
   - uid: 12124
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-4.5
       parent: 2
   - uid: 12125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-5.5
       parent: 2
   - uid: 12126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-6.5
       parent: 2
   - uid: 12127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-7.5
       parent: 2
   - uid: 12129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,35.5
       parent: 2
   - uid: 12131
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-4.5
       parent: 2
   - uid: 12132
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-5.5
       parent: 2
   - uid: 12133
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -84.5,-6.5
       parent: 2
   - uid: 12135
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,-4.5
       parent: 2
   - uid: 12136
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -82.5,-3.5
       parent: 2
   - uid: 12137
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,7.5
       parent: 2
   - uid: 12172
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,13.5
       parent: 2
   - uid: 12173
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,14.5
       parent: 2
   - uid: 12179
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,3.5
       parent: 2
   - uid: 12180
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,4.5
       parent: 2
   - uid: 12181
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,3.5
       parent: 2
   - uid: 12183
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,3.5
       parent: 2
   - uid: 12185
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,-0.5
       parent: 2
   - uid: 12186
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,0.5
       parent: 2
   - uid: 12188
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,3.5
       parent: 2
   - uid: 12189
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,4.5
       parent: 2
   - uid: 12190
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,3.5
       parent: 2
   - uid: 12191
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,4.5
       parent: 2
   - uid: 12196
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,6.5
       parent: 2
   - uid: 12197
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,43.5
       parent: 2
   - uid: 12198
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,6.5
       parent: 2
   - uid: 12210
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,12.5
       parent: 2
   - uid: 12211
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,7.5
       parent: 2
   - uid: 12213
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,9.5
       parent: 2
   - uid: 12215
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,11.5
       parent: 2
   - uid: 12216
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,12.5
       parent: 2
   - uid: 12217
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,7.5
       parent: 2
   - uid: 12218
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,8.5
       parent: 2
   - uid: 12219
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,9.5
       parent: 2
   - uid: 12223
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,7.5
       parent: 2
   - uid: 12224
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,8.5
       parent: 2
   - uid: 12236
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,14.5
       parent: 2
   - uid: 12237
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,15.5
       parent: 2
   - uid: 12239
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,14.5
       parent: 2
   - uid: 12240
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -79.5,15.5
       parent: 2
   - uid: 12242
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,14.5
       parent: 2
   - uid: 12243
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,15.5
       parent: 2
   - uid: 12245
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,14.5
       parent: 2
   - uid: 12246
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,15.5
       parent: 2
   - uid: 12247
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,13.5
       parent: 2
   - uid: 12248
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,14.5
       parent: 2
   - uid: 12249
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -76.5,15.5
       parent: 2
   - uid: 12250
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,13.5
       parent: 2
   - uid: 12251
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,14.5
       parent: 2
   - uid: 12252
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,15.5
       parent: 2
   - uid: 12253
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,13.5
       parent: 2
   - uid: 12254
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,14.5
       parent: 2
   - uid: 12255
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,15.5
       parent: 2
   - uid: 12257
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,14.5
       parent: 2
   - uid: 12259
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,14.5
       parent: 2
   - uid: 12260
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,42.5
       parent: 2
   - uid: 12262
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,15.5
       parent: 2
   - uid: 12263
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,15.5
       parent: 2
   - uid: 12264
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,15.5
       parent: 2
   - uid: 12265
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,15.5
       parent: 2
   - uid: 12266
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,15.5
       parent: 2
   - uid: 12267
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,15.5
       parent: 2
   - uid: 12268
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,15.5
       parent: 2
   - uid: 12269
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,15.5
       parent: 2
   - uid: 12270
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,15.5
       parent: 2
   - uid: 12271
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,-5.5
       parent: 2
   - uid: 12273
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,4.5
       parent: 2
   - uid: 12274
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,11.5
       parent: 2
   - uid: 12275
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,12.5
       parent: 2
   - uid: 12276
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,6.5
       parent: 2
   - uid: 12278
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,14.5
       parent: 2
   - uid: 12279
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,14.5
       parent: 2
   - uid: 12280
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,14.5
       parent: 2
   - uid: 12286
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,3.5
       parent: 2
   - uid: 12287
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,-1.5
       parent: 2
   - uid: 12289
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,1.5
       parent: 2
   - uid: 12290
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,13.5
       parent: 2
   - uid: 12291
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,13.5
       parent: 2
   - uid: 12296
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,12.5
       parent: 2
   - uid: 12298
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,5.5
       parent: 2
   - uid: 12299
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,41.5
       parent: 2
   - uid: 12301
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,6.5
       parent: 2
   - uid: 12302
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,7.5
       parent: 2
   - uid: 12303
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,6.5
       parent: 2
   - uid: 12304
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,7.5
       parent: 2
   - uid: 12305
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,6.5
       parent: 2
   - uid: 12308
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,8.5
       parent: 2
   - uid: 12309
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,9.5
       parent: 2
   - uid: 12311
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,9.5
       parent: 2
   - uid: 12314
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,43.5
       parent: 2
   - uid: 12317
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,34.5
       parent: 2
   - uid: 12319
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,9.5
       parent: 2
   - uid: 12322
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,8.5
       parent: 2
   - uid: 12323
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,9.5
       parent: 2
   - uid: 12324
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,10.5
       parent: 2
   - uid: 12327
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,10.5
       parent: 2
   - uid: 12328
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,10.5
       parent: 2
   - uid: 12329
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,8.5
       parent: 2
   - uid: 12330
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,9.5
       parent: 2
   - uid: 12334
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,8.5
       parent: 2
   - uid: 12397
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,3.5
       parent: 2
   - uid: 12405
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,2.5
       parent: 2
   - uid: 12406
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,2.5
       parent: 2
   - uid: 12423
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,43.5
       parent: 2
   - uid: 12430
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,43.5
       parent: 2
   - uid: 12441
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,41.5
       parent: 2
   - uid: 12442
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,40.5
       parent: 2
   - uid: 12443
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,39.5
       parent: 2
   - uid: 12444
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,38.5
       parent: 2
   - uid: 12445
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,37.5
       parent: 2
   - uid: 12446
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,36.5
       parent: 2
   - uid: 12447
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,35.5
       parent: 2
   - uid: 12450
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,42.5
       parent: 2
   - uid: 12451
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,41.5
       parent: 2
   - uid: 12452
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,40.5
       parent: 2
   - uid: 12453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,39.5
       parent: 2
   - uid: 12454
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,38.5
       parent: 2
   - uid: 12455
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,37.5
       parent: 2
   - uid: 12457
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,35.5
       parent: 2
   - uid: 12460
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,42.5
       parent: 2
   - uid: 12465
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,37.5
       parent: 2
   - uid: 12466
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,36.5
       parent: 2
   - uid: 12467
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,35.5
       parent: 2
   - uid: 12476
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,35.5
       parent: 2
   - uid: 12477
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,43.5
       parent: 2
   - uid: 12485
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,35.5
       parent: 2
   - uid: 12488
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,35.5
       parent: 2
   - uid: 12491
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,35.5
       parent: 2
   - uid: 12492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,35.5
       parent: 2
   - uid: 12494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,34.5
       parent: 2
   - uid: 12495
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,34.5
       parent: 2
   - uid: 12496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,34.5
       parent: 2
   - uid: 12497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,34.5
       parent: 2
   - uid: 12498
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,34.5
       parent: 2
   - uid: 12499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,34.5
       parent: 2
   - uid: 12511
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,38.5
       parent: 2
   - uid: 12512
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,37.5
       parent: 2
   - uid: 12513
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,36.5
       parent: 2
   - uid: 12514
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,35.5
       parent: 2
   - uid: 12518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,37.5
       parent: 2
   - uid: 12519
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,36.5
       parent: 2
   - uid: 12520
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,35.5
       parent: 2
   - uid: 12523
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,37.5
       parent: 2
   - uid: 12524
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,36.5
       parent: 2
   - uid: 12525
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,35.5
       parent: 2
   - uid: 12529
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,36.5
       parent: 2
   - uid: 12530
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,35.5
       parent: 2
   - uid: 12531
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,35.5
       parent: 2
   - uid: 12532
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,36.5
       parent: 2
   - uid: 12547
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,35.5
       parent: 2
   - uid: 12563
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,33.5
       parent: 2
   - uid: 12569
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -83.5,-8.5
       parent: 2
   - uid: 12813
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,41.5
       parent: 2
   - uid: 12915
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,41.5
       parent: 2
   - uid: 12930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,25.5
       parent: 2
   - uid: 12944
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,25.5
       parent: 2
   - uid: 12962
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,25.5
       parent: 2
   - uid: 12965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,16.5
       parent: 2
   - uid: 12970
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,15.5
       parent: 2
   - uid: 12972
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,15.5
       parent: 2
   - uid: 12983
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -46.5,0.5
       parent: 2
   - uid: 13076
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,4.5
       parent: 2
   - uid: 13085
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,2.5
       parent: 2
   - uid: 13086
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,38.5
       parent: 2
   - uid: 13087
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,37.5
       parent: 2
   - uid: 13090
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,11.5
       parent: 2
   - uid: 13091
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-2.5
       parent: 2
   - uid: 13095
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,36.5
       parent: 2
   - uid: 13097
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -78.5,-5.5
       parent: 2
   - uid: 13100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,-4.5
       parent: 2
   - uid: 13142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,1.5
       parent: 2
   - uid: 13181
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,40.5
       parent: 2
   - uid: 13238
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,10.5
       parent: 2
   - uid: 13242
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,9.5
       parent: 2
   - uid: 13245
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,9.5
       parent: 2
   - uid: 13259
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,4.5
       parent: 2
   - uid: 13260
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,4.5
       parent: 2
   - uid: 13273
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,8.5
       parent: 2
   - uid: 13274
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,8.5
       parent: 2
   - uid: 13282
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -67.5,11.5
       parent: 2
   - uid: 13283
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,12.5
       parent: 2
   - uid: 13284
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,11.5
       parent: 2
   - uid: 13285
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,10.5
       parent: 2
   - uid: 13286
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,9.5
       parent: 2
   - uid: 13287
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,12.5
       parent: 2
   - uid: 13288
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,5.5
       parent: 2
   - uid: 13289
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,5.5
       parent: 2
   - uid: 13291
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,2.5
       parent: 2
   - uid: 13292
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -55.5,3.5
       parent: 2
   - uid: 13293
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,3.5
       parent: 2
   - uid: 13294
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,3.5
       parent: 2
   - uid: 13295
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -52.5,2.5
       parent: 2
   - uid: 13296
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,5.5
       parent: 2
   - uid: 13339
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -61.5,9.5
       parent: 2
   - uid: 13478
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -53.5,31.5
       parent: 2
   - uid: 13481
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,31.5
       parent: 2
   - uid: 13649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,6.5
       parent: 2
   - uid: 13655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,43.5
       parent: 2
   - uid: 14406
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-24.5
       parent: 2
   - uid: 14408
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-23.5
       parent: 2
   - uid: 14603
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,35.5
       parent: 2
   - uid: 14604
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,34.5
       parent: 2
   - uid: 14605
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,35.5
       parent: 2
   - uid: 14607
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,35.5
       parent: 2
   - uid: 14634
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,34.5
       parent: 2
   - uid: 14638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,34.5
       parent: 2
   - uid: 14653
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,33.5
       parent: 2
   - uid: 14655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,33.5
       parent: 2
   - uid: 14673
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,33.5
       parent: 2
   - uid: 14689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,34.5
       parent: 2
   - uid: 14690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,32.5
       parent: 2
   - uid: 14692
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-3.5
       parent: 2
   - uid: 14954
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-23.5
       parent: 2
   - uid: 14981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -57.5,39.5
       parent: 2
   - uid: 15064
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,29.5
       parent: 2
   - uid: 15636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,42.5
       parent: 2
   - uid: 15730
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,43.5
       parent: 2
   - uid: 15928
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,44.5
       parent: 2
   - uid: 15938
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -63.5,39.5
       parent: 2
   - uid: 15943
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -62.5,39.5
       parent: 2
   - uid: 16103
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,40.5
       parent: 2
   - uid: 17295
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -68.5,36.5
       parent: 2
   - uid: 17499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-22.5
       parent: 2
   - uid: 17500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-21.5
       parent: 2
   - uid: 17502
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-21.5
       parent: 2
   - uid: 17503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-22.5
       parent: 2
@@ -113627,43 +104790,31 @@ entities:
   entities:
   - uid: 8768
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-28.5
       parent: 2
   - uid: 9440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -19.5,-28.5
       parent: 2
   - uid: 11807
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-24.5
       parent: 2
   - uid: 11842
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -10.5,-33.5
       parent: 2
   - uid: 11895
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,10.5
       parent: 2
   - uid: 13096
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -56.5,-10.5
       parent: 2
@@ -113671,36 +104822,26 @@ entities:
   entities:
   - uid: 9538
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -36.5,-2.5
       parent: 2
   - uid: 12212
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-24.5
       parent: 2
   - uid: 12438
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -59.5,-19.5
       parent: 2
   - uid: 13074
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-15.5
       parent: 2
   - uid: 13290
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -80.5,5.5
       parent: 2
@@ -113708,50 +104849,36 @@ entities:
   entities:
   - uid: 8720
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,3.5
       parent: 2
   - uid: 9453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-9.5
       parent: 2
   - uid: 12140
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -66.5,-25.5
       parent: 2
   - uid: 12156
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -64.5,-26.5
       parent: 2
   - uid: 14492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -73.5,6.5
       parent: 2
   - uid: 14493
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -75.5,3.5
       parent: 2
   - uid: 14496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -71.5,5.5
       parent: 2
@@ -113759,8 +104886,6 @@ entities:
   entities:
   - uid: 14499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -81.5,-3.5
       parent: 2
@@ -113768,15 +104893,11 @@ entities:
   entities:
   - uid: 13660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,12.5
       parent: 2
   - uid: 14501
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -74.5,8.5
       parent: 2
@@ -113784,57 +104905,41 @@ entities:
   entities:
   - uid: 9271
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -70.5,-2.5
       parent: 2
   - uid: 11844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-1.5
       parent: 2
   - uid: 11870
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -51.5,-0.5
       parent: 2
   - uid: 11872
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -60.5,3.5
       parent: 2
   - uid: 11897
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -45.5,9.5
       parent: 2
   - uid: 13075
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -58.5,-14.5
       parent: 2
   - uid: 14494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -72.5,-0.5
       parent: 2
   - uid: 14497
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -65.5,-0.5
       parent: 2
@@ -113842,8 +104947,6 @@ entities:
   entities:
   - uid: 14503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -77.5,-5.5
       parent: 2
@@ -113851,3333 +104954,2381 @@ entities:
   entities:
   - uid: 1047
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,24.5
       parent: 2
   - uid: 2116
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-4.5
       parent: 2
   - uid: 2619
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-1.5
       parent: 2
   - uid: 2620
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-16.5
       parent: 2
   - uid: 2621
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-16.5
       parent: 2
   - uid: 2622
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-16.5
       parent: 2
   - uid: 2623
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-15.5
       parent: 2
   - uid: 2624
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-14.5
       parent: 2
   - uid: 2830
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,20.5
       parent: 2
   - uid: 2878
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,20.5
       parent: 2
   - uid: 3129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-18.5
       parent: 2
   - uid: 3172
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-17.5
       parent: 2
   - uid: 3827
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-17.5
       parent: 2
   - uid: 3828
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-18.5
       parent: 2
   - uid: 3895
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-17.5
       parent: 2
   - uid: 3896
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-18.5
       parent: 2
   - uid: 3930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-15.5
       parent: 2
   - uid: 3933
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-10.5
       parent: 2
   - uid: 3935
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-12.5
       parent: 2
   - uid: 3936
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-9.5
       parent: 2
   - uid: 3937
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-10.5
       parent: 2
   - uid: 3938
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-12.5
       parent: 2
   - uid: 3939
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-12.5
       parent: 2
   - uid: 3941
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-15.5
       parent: 2
   - uid: 3943
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-13.5
       parent: 2
   - uid: 3944
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-12.5
       parent: 2
   - uid: 3950
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-16.5
       parent: 2
   - uid: 3951
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-13.5
       parent: 2
   - uid: 3957
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-24.5
       parent: 2
   - uid: 3963
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-24.5
       parent: 2
   - uid: 3976
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-25.5
       parent: 2
   - uid: 3977
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-14.5
       parent: 2
   - uid: 3978
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-12.5
       parent: 2
   - uid: 3979
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-22.5
       parent: 2
   - uid: 3980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-22.5
       parent: 2
   - uid: 3982
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-21.5
       parent: 2
   - uid: 3984
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-22.5
       parent: 2
   - uid: 3986
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-22.5
       parent: 2
   - uid: 3989
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-20.5
       parent: 2
   - uid: 3991
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-21.5
       parent: 2
   - uid: 3992
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-21.5
       parent: 2
   - uid: 3993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-23.5
       parent: 2
   - uid: 3998
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-19.5
       parent: 2
   - uid: 4004
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-20.5
       parent: 2
   - uid: 4009
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-20.5
       parent: 2
   - uid: 4010
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-20.5
       parent: 2
   - uid: 4011
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-19.5
       parent: 2
   - uid: 4013
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-19.5
       parent: 2
   - uid: 4014
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-19.5
       parent: 2
   - uid: 4015
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-20.5
       parent: 2
   - uid: 4034
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-26.5
       parent: 2
   - uid: 4035
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-26.5
       parent: 2
   - uid: 4036
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-25.5
       parent: 2
   - uid: 4039
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-25.5
       parent: 2
   - uid: 4060
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-5.5
       parent: 2
   - uid: 4435
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-24.5
       parent: 2
   - uid: 4436
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-23.5
       parent: 2
   - uid: 4437
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-23.5
       parent: 2
   - uid: 4442
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-22.5
       parent: 2
   - uid: 4447
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-12.5
       parent: 2
   - uid: 4448
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-23.5
       parent: 2
   - uid: 4449
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-21.5
       parent: 2
   - uid: 4450
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-24.5
       parent: 2
   - uid: 4451
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-22.5
       parent: 2
   - uid: 4456
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-23.5
       parent: 2
   - uid: 4457
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-24.5
       parent: 2
   - uid: 4465
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-21.5
       parent: 2
   - uid: 4473
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-8.5
       parent: 2
   - uid: 4478
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-8.5
       parent: 2
   - uid: 4483
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-10.5
       parent: 2
   - uid: 4494
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-8.5
       parent: 2
   - uid: 4496
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-8.5
       parent: 2
   - uid: 4499
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-10.5
       parent: 2
   - uid: 4500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-9.5
       parent: 2
   - uid: 4503
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-8.5
       parent: 2
   - uid: 4504
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-9.5
       parent: 2
   - uid: 4505
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-11.5
       parent: 2
   - uid: 4508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-12.5
       parent: 2
   - uid: 4509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,-11.5
       parent: 2
   - uid: 4519
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-11.5
       parent: 2
   - uid: 4522
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-18.5
       parent: 2
   - uid: 4523
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-17.5
       parent: 2
   - uid: 4524
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-16.5
       parent: 2
   - uid: 4534
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-16.5
       parent: 2
   - uid: 4535
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-15.5
       parent: 2
   - uid: 4536
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-14.5
       parent: 2
   - uid: 4537
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-13.5
       parent: 2
   - uid: 4538
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-15.5
       parent: 2
   - uid: 4572
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-11.5
       parent: 2
   - uid: 4576
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-10.5
       parent: 2
   - uid: 4577
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-9.5
       parent: 2
   - uid: 4578
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-10.5
       parent: 2
   - uid: 4579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-9.5
       parent: 2
   - uid: 4580
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-10.5
       parent: 2
   - uid: 4581
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-9.5
       parent: 2
   - uid: 4582
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-10.5
       parent: 2
   - uid: 4583
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-9.5
       parent: 2
   - uid: 4585
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-9.5
       parent: 2
   - uid: 4600
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-8.5
       parent: 2
   - uid: 4601
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-8.5
       parent: 2
   - uid: 4602
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-8.5
       parent: 2
   - uid: 4603
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-8.5
       parent: 2
   - uid: 4604
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-8.5
       parent: 2
   - uid: 4605
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-8.5
       parent: 2
   - uid: 4606
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-8.5
       parent: 2
   - uid: 4607
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-8.5
       parent: 2
   - uid: 4617
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-6.5
       parent: 2
   - uid: 4618
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-5.5
       parent: 2
   - uid: 4619
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-4.5
       parent: 2
   - uid: 4621
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-6.5
       parent: 2
   - uid: 4622
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-5.5
       parent: 2
   - uid: 4623
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-4.5
       parent: 2
   - uid: 4624
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-7.5
       parent: 2
   - uid: 4625
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-6.5
       parent: 2
   - uid: 4626
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-5.5
       parent: 2
   - uid: 4627
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-4.5
       parent: 2
   - uid: 4628
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-7.5
       parent: 2
   - uid: 4629
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-6.5
       parent: 2
   - uid: 4630
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-5.5
       parent: 2
   - uid: 4631
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-4.5
       parent: 2
   - uid: 4632
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-7.5
       parent: 2
   - uid: 4633
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-6.5
       parent: 2
   - uid: 4634
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-5.5
       parent: 2
   - uid: 4635
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-4.5
       parent: 2
   - uid: 4636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-7.5
       parent: 2
   - uid: 4637
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-6.5
       parent: 2
   - uid: 4638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-5.5
       parent: 2
   - uid: 4639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-4.5
       parent: 2
   - uid: 4640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-7.5
       parent: 2
   - uid: 4641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-6.5
       parent: 2
   - uid: 4644
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
   - uid: 4648
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-7.5
       parent: 2
   - uid: 4649
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-6.5
       parent: 2
   - uid: 4650
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-5.5
       parent: 2
   - uid: 4651
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-4.5
       parent: 2
   - uid: 4652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-7.5
       parent: 2
   - uid: 4653
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-6.5
       parent: 2
   - uid: 4654
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-5.5
       parent: 2
   - uid: 4655
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-4.5
       parent: 2
   - uid: 4656
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-7.5
       parent: 2
   - uid: 4657
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-6.5
       parent: 2
   - uid: 4658
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-5.5
       parent: 2
   - uid: 4659
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-4.5
       parent: 2
   - uid: 4663
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-4.5
       parent: 2
   - uid: 4684
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-7.5
       parent: 2
   - uid: 4688
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-7.5
       parent: 2
   - uid: 4689
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-6.5
       parent: 2
   - uid: 4690
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-5.5
       parent: 2
   - uid: 4691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-4.5
       parent: 2
   - uid: 4692
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-7.5
       parent: 2
   - uid: 4693
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-4.5
       parent: 2
   - uid: 4694
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-5.5
       parent: 2
   - uid: 4695
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-6.5
       parent: 2
   - uid: 4696
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-7.5
       parent: 2
   - uid: 4712
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-3.5
       parent: 2
   - uid: 4713
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-2.5
       parent: 2
   - uid: 4714
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-1.5
       parent: 2
   - uid: 4715
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,-0.5
       parent: 2
   - uid: 4716
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-3.5
       parent: 2
   - uid: 4717
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-2.5
       parent: 2
   - uid: 4718
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-1.5
       parent: 2
   - uid: 4719
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,-0.5
       parent: 2
   - uid: 4720
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-3.5
       parent: 2
   - uid: 4721
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-2.5
       parent: 2
   - uid: 4722
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-1.5
       parent: 2
   - uid: 4723
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,-0.5
       parent: 2
   - uid: 4724
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-3.5
       parent: 2
   - uid: 4725
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-2.5
       parent: 2
   - uid: 4726
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-1.5
       parent: 2
   - uid: 4727
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,-0.5
       parent: 2
   - uid: 4728
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-3.5
       parent: 2
   - uid: 4729
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-2.5
       parent: 2
   - uid: 4730
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-1.5
       parent: 2
   - uid: 4731
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,-0.5
       parent: 2
   - uid: 4732
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-3.5
       parent: 2
   - uid: 4735
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-0.5
       parent: 2
   - uid: 4736
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-3.5
       parent: 2
   - uid: 4748
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,-3.5
       parent: 2
   - uid: 4752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-3.5
       parent: 2
   - uid: 4753
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-2.5
       parent: 2
   - uid: 4754
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-1.5
       parent: 2
   - uid: 4756
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-3.5
       parent: 2
   - uid: 4757
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-2.5
       parent: 2
   - uid: 4775
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-0.5
       parent: 2
   - uid: 4776
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-3.5
       parent: 2
   - uid: 4777
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-2.5
       parent: 2
   - uid: 4778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-1.5
       parent: 2
   - uid: 4779
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-0.5
       parent: 2
   - uid: 4789
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-6.5
       parent: 2
   - uid: 4799
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,0.5
       parent: 2
   - uid: 4801
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,0.5
       parent: 2
   - uid: 4802
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,1.5
       parent: 2
   - uid: 4803
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,0.5
       parent: 2
   - uid: 4804
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,1.5
       parent: 2
   - uid: 4805
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,0.5
       parent: 2
   - uid: 4806
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,1.5
       parent: 2
   - uid: 4807
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,0.5
       parent: 2
   - uid: 4808
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,1.5
       parent: 2
   - uid: 4809
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,0.5
       parent: 2
   - uid: 4810
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,1.5
       parent: 2
   - uid: 4821
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,-4.5
       parent: 2
   - uid: 4853
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,2.5
       parent: 2
   - uid: 4856
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,2.5
       parent: 2
   - uid: 4859
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,2.5
       parent: 2
   - uid: 4870
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,2.5
       parent: 2
   - uid: 4871
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,2.5
       parent: 2
   - uid: 4934
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-6.5
       parent: 2
   - uid: 4935
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,-5.5
       parent: 2
   - uid: 4936
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-5.5
       parent: 2
   - uid: 4937
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-6.5
       parent: 2
   - uid: 4981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-8.5
       parent: 2
   - uid: 5064
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-2.5
       parent: 2
   - uid: 5098
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-1.5
       parent: 2
   - uid: 5099
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,-1.5
       parent: 2
   - uid: 5101
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-0.5
       parent: 2
   - uid: 5106
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-3.5
       parent: 2
   - uid: 5200
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,27.5
       parent: 2
   - uid: 5309
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,11.5
       parent: 2
   - uid: 5311
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,11.5
       parent: 2
   - uid: 5313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,11.5
       parent: 2
   - uid: 5314
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,10.5
       parent: 2
   - uid: 5315
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,11.5
       parent: 2
   - uid: 5316
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,10.5
       parent: 2
   - uid: 5328
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,13.5
       parent: 2
   - uid: 5329
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,14.5
       parent: 2
   - uid: 5330
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,15.5
       parent: 2
   - uid: 5333
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,14.5
       parent: 2
   - uid: 5334
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,15.5
       parent: 2
   - uid: 5337
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,14.5
       parent: 2
   - uid: 5342
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,15.5
       parent: 2
   - uid: 5343
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,12.5
       parent: 2
   - uid: 5346
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,15.5
       parent: 2
   - uid: 5347
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,12.5
       parent: 2
   - uid: 5348
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,13.5
       parent: 2
   - uid: 5352
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,13.5
       parent: 2
   - uid: 5372
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-3.5
       parent: 2
   - uid: 5375
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-4.5
       parent: 2
   - uid: 5376
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-5.5
       parent: 2
   - uid: 5377
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-6.5
       parent: 2
   - uid: 5378
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,-7.5
       parent: 2
   - uid: 5381
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-6.5
       parent: 2
   - uid: 5382
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,-7.5
       parent: 2
   - uid: 5383
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-6.5
       parent: 2
   - uid: 5384
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-7.5
       parent: 2
   - uid: 5385
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-6.5
       parent: 2
   - uid: 5386
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,-7.5
       parent: 2
   - uid: 5389
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,18.5
       parent: 2
   - uid: 5390
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-7.5
       parent: 2
   - uid: 5391
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,-6.5
       parent: 2
   - uid: 5392
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-4.5
       parent: 2
   - uid: 5393
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-3.5
       parent: 2
   - uid: 5396
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 23.5,-8.5
       parent: 2
   - uid: 5412
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,11.5
       parent: 2
   - uid: 5413
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,12.5
       parent: 2
   - uid: 5462
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,17.5
       parent: 2
   - uid: 5479
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,19.5
       parent: 2
   - uid: 5481
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,20.5
       parent: 2
   - uid: 5896
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-13.5
       parent: 2
   - uid: 5902
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-12.5
       parent: 2
   - uid: 5907
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-14.5
       parent: 2
   - uid: 6314
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,23.5
       parent: 2
   - uid: 6490
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-15.5
       parent: 2
   - uid: 6565
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,43.5
       parent: 2
   - uid: 6566
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,42.5
       parent: 2
   - uid: 6567
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,43.5
       parent: 2
   - uid: 6568
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,42.5
       parent: 2
   - uid: 6569
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,43.5
       parent: 2
   - uid: 6570
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,42.5
       parent: 2
   - uid: 6571
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,41.5
       parent: 2
   - uid: 6572
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,40.5
       parent: 2
   - uid: 6573
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,39.5
       parent: 2
   - uid: 6574
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,41.5
       parent: 2
   - uid: 6575
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,40.5
       parent: 2
   - uid: 6576
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,39.5
       parent: 2
   - uid: 6577
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,41.5
       parent: 2
   - uid: 6578
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,40.5
       parent: 2
   - uid: 6579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,39.5
       parent: 2
   - uid: 6581
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,40.5
       parent: 2
   - uid: 6582
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,39.5
       parent: 2
   - uid: 6596
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,36.5
       parent: 2
   - uid: 6597
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,35.5
       parent: 2
   - uid: 6598
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,35.5
       parent: 2
   - uid: 6599
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,34.5
       parent: 2
   - uid: 6600
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,34.5
       parent: 2
   - uid: 6601
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,34.5
       parent: 2
   - uid: 6602
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,39.5
       parent: 2
   - uid: 6603
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,39.5
       parent: 2
   - uid: 6604
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,39.5
       parent: 2
   - uid: 6605
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,39.5
       parent: 2
   - uid: 6606
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,39.5
       parent: 2
   - uid: 6609
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,38.5
       parent: 2
   - uid: 6610
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,37.5
       parent: 2
   - uid: 6611
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,38.5
       parent: 2
   - uid: 6612
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,37.5
       parent: 2
   - uid: 6613
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,38.5
       parent: 2
   - uid: 6614
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,37.5
       parent: 2
   - uid: 6615
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,38.5
       parent: 2
   - uid: 6616
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,37.5
       parent: 2
   - uid: 6617
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,38.5
       parent: 2
   - uid: 6618
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,37.5
       parent: 2
   - uid: 6619
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,38.5
       parent: 2
   - uid: 6620
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,37.5
       parent: 2
   - uid: 6621
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,38.5
       parent: 2
   - uid: 6622
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,37.5
       parent: 2
   - uid: 6624
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,37.5
       parent: 2
   - uid: 6633
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,36.5
       parent: 2
   - uid: 6635
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,36.5
       parent: 2
   - uid: 6637
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,36.5
       parent: 2
   - uid: 6639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,36.5
       parent: 2
   - uid: 6641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,36.5
       parent: 2
   - uid: 6643
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,36.5
       parent: 2
   - uid: 6644
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,35.5
       parent: 2
   - uid: 6645
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,36.5
       parent: 2
   - uid: 6658
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,31.5
       parent: 2
   - uid: 6660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,30.5
       parent: 2
   - uid: 6661
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,31.5
       parent: 2
   - uid: 6662
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,32.5
       parent: 2
   - uid: 6663
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,33.5
       parent: 2
   - uid: 6664
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,31.5
       parent: 2
   - uid: 6665
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,32.5
       parent: 2
   - uid: 6666
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,33.5
       parent: 2
   - uid: 6667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,31.5
       parent: 2
   - uid: 6668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,32.5
       parent: 2
   - uid: 6669
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,33.5
       parent: 2
   - uid: 6671
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,32.5
       parent: 2
   - uid: 6672
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,33.5
       parent: 2
   - uid: 6678
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,30.5
       parent: 2
   - uid: 6679
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,29.5
       parent: 2
   - uid: 6680
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,30.5
       parent: 2
   - uid: 6681
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,29.5
       parent: 2
   - uid: 6682
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,30.5
       parent: 2
   - uid: 6721
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,25.5
       parent: 2
   - uid: 6722
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,24.5
       parent: 2
   - uid: 6725
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,21.5
       parent: 2
   - uid: 6730
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,25.5
       parent: 2
   - uid: 6739
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,24.5
       parent: 2
   - uid: 6740
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,25.5
       parent: 2
   - uid: 6742
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,24.5
       parent: 2
   - uid: 6745
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,21.5
       parent: 2
   - uid: 6749
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,25.5
       parent: 2
   - uid: 6752
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,21.5
       parent: 2
   - uid: 6851
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,29.5
       parent: 2
   - uid: 6852
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,29.5
       parent: 2
   - uid: 6858
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,28.5
       parent: 2
   - uid: 6861
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,28.5
       parent: 2
   - uid: 6862
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,27.5
       parent: 2
   - uid: 6863
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,26.5
       parent: 2
   - uid: 6864
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,28.5
       parent: 2
   - uid: 6865
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,27.5
       parent: 2
   - uid: 6866
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,26.5
       parent: 2
   - uid: 6868
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,27.5
       parent: 2
   - uid: 6869
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,26.5
       parent: 2
   - uid: 6878
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,25.5
       parent: 2
   - uid: 6883
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,25.5
       parent: 2
   - uid: 6884
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,24.5
       parent: 2
   - uid: 6889
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,21.5
       parent: 2
   - uid: 6892
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,24.5
       parent: 2
   - uid: 6893
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,25.5
       parent: 2
   - uid: 6894
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,21.5
       parent: 2
   - uid: 6897
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,24.5
       parent: 2
   - uid: 6898
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,25.5
       parent: 2
   - uid: 6899
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,21.5
       parent: 2
   - uid: 6901
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,23.5
       parent: 2
   - uid: 6902
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,24.5
       parent: 2
   - uid: 6903
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,25.5
       parent: 2
   - uid: 6904
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,21.5
       parent: 2
   - uid: 6906
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 34.5,23.5
       parent: 2
   - uid: 6910
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,27.5
       parent: 2
   - uid: 6911
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,26.5
       parent: 2
   - uid: 6912
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,25.5
       parent: 2
   - uid: 6918
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,28.5
       parent: 2
   - uid: 6919
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,27.5
       parent: 2
   - uid: 6920
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,26.5
       parent: 2
   - uid: 6921
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,25.5
       parent: 2
   - uid: 6922
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,24.5
       parent: 2
   - uid: 6927
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,28.5
       parent: 2
   - uid: 6928
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,27.5
       parent: 2
   - uid: 6929
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,26.5
       parent: 2
   - uid: 6930
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,25.5
       parent: 2
   - uid: 6937
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,27.5
       parent: 2
   - uid: 6944
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,20.5
       parent: 2
   - uid: 6946
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,27.5
       parent: 2
   - uid: 6947
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,26.5
       parent: 2
   - uid: 6953
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,20.5
       parent: 2
   - uid: 6955
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,27.5
       parent: 2
   - uid: 6956
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,26.5
       parent: 2
   - uid: 6962
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,20.5
       parent: 2
   - uid: 6965
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,26.5
       parent: 2
   - uid: 6972
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,25.5
       parent: 2
   - uid: 6973
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,24.5
       parent: 2
   - uid: 6974
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,23.5
       parent: 2
   - uid: 6978
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,16.5
       parent: 2
   - uid: 6979
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,17.5
       parent: 2
   - uid: 6980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,18.5
       parent: 2
   - uid: 6981
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,19.5
       parent: 2
   - uid: 6982
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,20.5
       parent: 2
   - uid: 6983
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,16.5
       parent: 2
   - uid: 6984
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,17.5
       parent: 2
   - uid: 6985
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,18.5
       parent: 2
   - uid: 6986
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,19.5
       parent: 2
   - uid: 6988
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,16.5
       parent: 2
   - uid: 6989
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,17.5
       parent: 2
   - uid: 6990
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,18.5
       parent: 2
   - uid: 6993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,16.5
       parent: 2
   - uid: 6994
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,17.5
       parent: 2
   - uid: 6995
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,18.5
       parent: 2
   - uid: 6997
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,16.5
       parent: 2
   - uid: 6998
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,17.5
       parent: 2
   - uid: 7001
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,16.5
       parent: 2
   - uid: 7003
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,21.5
       parent: 2
   - uid: 7005
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,20.5
       parent: 2
   - uid: 7014
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,19.5
       parent: 2
   - uid: 7015
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,18.5
       parent: 2
   - uid: 7016
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,19.5
       parent: 2
   - uid: 7017
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,16.5
       parent: 2
   - uid: 7018
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,17.5
       parent: 2
   - uid: 7019
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,18.5
       parent: 2
   - uid: 7020
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,19.5
       parent: 2
   - uid: 7021
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,16.5
       parent: 2
   - uid: 7022
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,17.5
       parent: 2
   - uid: 7023
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,18.5
       parent: 2
   - uid: 7027
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,18.5
       parent: 2
   - uid: 7028
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,19.5
       parent: 2
   - uid: 7029
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,20.5
       parent: 2
   - uid: 7068
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,20.5
       parent: 2
   - uid: 7070
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,19.5
       parent: 2
   - uid: 7071
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,19.5
       parent: 2
   - uid: 7074
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,19.5
       parent: 2
   - uid: 7080
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,19.5
       parent: 2
   - uid: 7097
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,18.5
       parent: 2
   - uid: 7098
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,17.5
       parent: 2
   - uid: 7099
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 51.5,16.5
       parent: 2
   - uid: 7109
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,15.5
       parent: 2
   - uid: 7110
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,15.5
       parent: 2
   - uid: 7113
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,15.5
       parent: 2
   - uid: 7114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,15.5
       parent: 2
   - uid: 7115
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,15.5
       parent: 2
   - uid: 7121
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 49.5,14.5
       parent: 2
   - uid: 7122
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 48.5,14.5
       parent: 2
   - uid: 7123
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,14.5
       parent: 2
   - uid: 7124
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,14.5
       parent: 2
   - uid: 7125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,14.5
       parent: 2
   - uid: 7126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,14.5
       parent: 2
   - uid: 7135
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,13.5
       parent: 2
   - uid: 7148
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,12.5
       parent: 2
   - uid: 7447
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,28.5
       parent: 2
   - uid: 8048
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 40.5,-12.5
       parent: 2
   - uid: 8052
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,-11.5
       parent: 2
   - uid: 8069
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,-3.5
       parent: 2
   - uid: 8095
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 38.5,28.5
       parent: 2
   - uid: 8097
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,28.5
       parent: 2
   - uid: 8130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,28.5
       parent: 2
   - uid: 8132
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,-10.5
       parent: 2
   - uid: 8210
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 33.5,-16.5
       parent: 2
   - uid: 8232
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 36.5,-10.5
       parent: 2
   - uid: 8260
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,28.5
       parent: 2
   - uid: 9427
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,23.5
       parent: 2
   - uid: 9428
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,18.5
       parent: 2
   - uid: 9433
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,13.5
       parent: 2
   - uid: 9434
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 47.5,13.5
       parent: 2
   - uid: 9490
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-3.5
       parent: 2
   - uid: 9491
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-4.5
       parent: 2
   - uid: 9492
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-2.5
       parent: 2
   - uid: 9493
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 46.5,-1.5
       parent: 2
   - uid: 12060
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,25.5
       parent: 2
   - uid: 14561
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,23.5
       parent: 2
   - uid: 14648
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,19.5
       parent: 2
   - uid: 14656
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,22.5
       parent: 2
   - uid: 14659
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,22.5
       parent: 2
   - uid: 14663
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 25.5,19.5
       parent: 2
   - uid: 14665
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,20.5
       parent: 2
   - uid: 14666
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,19.5
       parent: 2
   - uid: 15421
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,20.5
       parent: 2
   - uid: 16836
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,20.5
       parent: 2
   - uid: 16854
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 43.5,25.5
       parent: 2
   - uid: 16987
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 50.5,16.5
       parent: 2
@@ -117185,15 +107336,11 @@ entities:
   entities:
   - uid: 4980
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,-13.5
       parent: 2
   - uid: 5500
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 35.5,0.5
       parent: 2
@@ -117201,22 +107348,16 @@ entities:
   entities:
   - uid: 14520
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 41.5,14.5
       parent: 2
   - uid: 14523
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 28.5,24.5
       parent: 2
   - uid: 14525
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,24.5
       parent: 2
@@ -117224,8 +107365,6 @@ entities:
   entities:
   - uid: 14526
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,20.5
       parent: 2
@@ -117233,15 +107372,11 @@ entities:
   entities:
   - uid: 14518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 37.5,15.5
       parent: 2
   - uid: 14521
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,38.5
       parent: 2
@@ -117249,15 +107384,11 @@ entities:
   entities:
   - uid: 14528
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 42.5,26.5
       parent: 2
   - uid: 14652
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,19.5
       parent: 2
@@ -117265,71 +107396,51 @@ entities:
   entities:
   - uid: 14505
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-21.5
       parent: 2
   - uid: 14508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 32.5,-23.5
       parent: 2
   - uid: 14509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 31.5,-9.5
       parent: 2
   - uid: 14510
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 24.5,-11.5
       parent: 2
   - uid: 14511
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-5.5
       parent: 2
   - uid: 14512
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,-4.5
       parent: 2
   - uid: 14513
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-6.5
       parent: 2
   - uid: 14514
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 44.5,-5.5
       parent: 2
   - uid: 14515
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 45.5,1.5
       parent: 2
   - uid: 14517
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 39.5,-0.5
       parent: 2
@@ -117337,22 +107448,16 @@ entities:
   entities:
   - uid: 7081
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,41.5
       parent: 2
   - uid: 7085
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,31.5
       parent: 2
   - uid: 7843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,29.5
       parent: 2
@@ -117360,22 +107465,16 @@ entities:
   entities:
   - uid: 3406
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-9.5
       parent: 2
   - uid: 3411
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-19.5
       parent: 2
   - uid: 8100
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,14.5
       parent: 2
@@ -117383,1204 +107482,864 @@ entities:
   entities:
   - uid: 2518
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-45.5
       parent: 2
   - uid: 2519
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-45.5
       parent: 2
   - uid: 2984
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-41.5
       parent: 2
   - uid: 2985
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-41.5
       parent: 2
   - uid: 2986
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-41.5
       parent: 2
   - uid: 2987
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-41.5
       parent: 2
   - uid: 2988
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-41.5
       parent: 2
   - uid: 2989
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-41.5
       parent: 2
   - uid: 2990
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-42.5
       parent: 2
   - uid: 2991
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-44.5
       parent: 2
   - uid: 2992
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,-45.5
       parent: 2
   - uid: 2993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-45.5
       parent: 2
   - uid: 2994
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-45.5
       parent: 2
   - uid: 2995
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-45.5
       parent: 2
   - uid: 3010
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-44.5
       parent: 2
   - uid: 3011
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-42.5
       parent: 2
   - uid: 6337
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,33.5
       parent: 2
   - uid: 6707
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,24.5
       parent: 2
   - uid: 6709
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,25.5
       parent: 2
   - uid: 6720
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,21.5
       parent: 2
   - uid: 6723
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,33.5
       parent: 2
   - uid: 6726
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,22.5
       parent: 2
   - uid: 6727
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,34.5
       parent: 2
   - uid: 6728
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,35.5
       parent: 2
   - uid: 6729
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,32.5
       parent: 2
   - uid: 6737
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,34.5
       parent: 2
   - uid: 6746
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,20.5
       parent: 2
   - uid: 6747
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,22.5
       parent: 2
   - uid: 6748
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,20.5
       parent: 2
   - uid: 6750
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,20.5
       parent: 2
   - uid: 6765
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,20.5
       parent: 2
   - uid: 6767
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,35.5
       parent: 2
   - uid: 6774
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,20.5
       parent: 2
   - uid: 6775
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,23.5
       parent: 2
   - uid: 6776
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,20.5
       parent: 2
   - uid: 6777
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,22.5
       parent: 2
   - uid: 6778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,22.5
       parent: 2
   - uid: 6779
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,22.5
       parent: 2
   - uid: 6780
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,22.5
       parent: 2
   - uid: 6781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,22.5
       parent: 2
   - uid: 6804
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,36.5
       parent: 2
   - uid: 6805
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,36.5
       parent: 2
   - uid: 6806
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,36.5
       parent: 2
   - uid: 6807
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,36.5
       parent: 2
   - uid: 6808
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,36.5
       parent: 2
   - uid: 6809
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,36.5
       parent: 2
   - uid: 6810
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,36.5
       parent: 2
   - uid: 6811
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,36.5
       parent: 2
   - uid: 6812
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,31.5
       parent: 2
   - uid: 6813
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,30.5
       parent: 2
   - uid: 6814
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,29.5
       parent: 2
   - uid: 6815
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,28.5
       parent: 2
   - uid: 6816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,27.5
       parent: 2
   - uid: 6817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,26.5
       parent: 2
   - uid: 6818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,25.5
       parent: 2
   - uid: 6819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,24.5
       parent: 2
   - uid: 6820
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,23.5
       parent: 2
   - uid: 6821
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,22.5
       parent: 2
   - uid: 6822
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,21.5
       parent: 2
   - uid: 6823
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,20.5
       parent: 2
   - uid: 6824
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,20.5
       parent: 2
   - uid: 6825
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,20.5
       parent: 2
   - uid: 6826
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,20.5
       parent: 2
   - uid: 6827
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,20.5
       parent: 2
   - uid: 6828
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,22.5
       parent: 2
   - uid: 6829
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,22.5
       parent: 2
   - uid: 6830
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,26.5
       parent: 2
   - uid: 6831
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,27.5
       parent: 2
   - uid: 6832
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,28.5
       parent: 2
   - uid: 6833
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,29.5
       parent: 2
   - uid: 6834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,30.5
       parent: 2
   - uid: 6835
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,31.5
       parent: 2
   - uid: 6836
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,32.5
       parent: 2
   - uid: 6837
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,33.5
       parent: 2
   - uid: 6838
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,34.5
       parent: 2
   - uid: 6839
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,33.5
       parent: 2
   - uid: 6840
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,34.5
       parent: 2
   - uid: 6841
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,34.5
       parent: 2
   - uid: 6842
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,34.5
       parent: 2
   - uid: 6843
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,34.5
       parent: 2
   - uid: 6844
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,31.5
       parent: 2
   - uid: 6845
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,30.5
       parent: 2
   - uid: 6846
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,29.5
       parent: 2
   - uid: 6847
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,28.5
       parent: 2
   - uid: 6848
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,27.5
       parent: 2
   - uid: 6849
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,27.5
       parent: 2
   - uid: 6856
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,30.5
       parent: 2
   - uid: 6857
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,30.5
       parent: 2
   - uid: 6859
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,26.5
       parent: 2
   - uid: 6870
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,30.5
       parent: 2
   - uid: 6871
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,30.5
       parent: 2
   - uid: 6872
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,27.5
       parent: 2
   - uid: 6873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,27.5
       parent: 2
   - uid: 6874
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,27.5
       parent: 2
   - uid: 6875
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,22.5
       parent: 2
   - uid: 6881
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,22.5
       parent: 2
   - uid: 6882
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,22.5
       parent: 2
   - uid: 6886
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,27.5
       parent: 2
   - uid: 6888
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,27.5
       parent: 2
   - uid: 6907
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,27.5
       parent: 2
   - uid: 6908
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,27.5
       parent: 2
   - uid: 6909
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,27.5
       parent: 2
   - uid: 7009
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,27.5
       parent: 2
   - uid: 7011
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,29.5
       parent: 2
   - uid: 7012
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,28.5
       parent: 2
   - uid: 7013
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,26.5
       parent: 2
   - uid: 7116
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,25.5
       parent: 2
   - uid: 7117
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,23.5
       parent: 2
   - uid: 7127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,24.5
       parent: 2
   - uid: 7128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,22.5
       parent: 2
   - uid: 7136
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,34.5
       parent: 2
   - uid: 7137
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,34.5
       parent: 2
   - uid: 7138
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,34.5
       parent: 2
   - uid: 7139
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,27.5
       parent: 2
   - uid: 7141
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,26.5
       parent: 2
   - uid: 7142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 12.5,23.5
       parent: 2
   - uid: 7149
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,34.5
       parent: 2
   - uid: 7152
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,23.5
       parent: 2
   - uid: 7157
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,34.5
       parent: 2
   - uid: 7158
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,34.5
       parent: 2
   - uid: 7159
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,34.5
       parent: 2
   - uid: 7162
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,22.5
       parent: 2
   - uid: 7163
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,21.5
       parent: 2
   - uid: 7164
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,20.5
       parent: 2
   - uid: 7166
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,20.5
       parent: 2
   - uid: 7167
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,20.5
       parent: 2
   - uid: 7172
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,20.5
       parent: 2
   - uid: 7173
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,20.5
       parent: 2
   - uid: 7174
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,20.5
       parent: 2
   - uid: 7175
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,20.5
       parent: 2
   - uid: 7176
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,21.5
       parent: 2
   - uid: 7177
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,22.5
       parent: 2
   - uid: 7178
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,23.5
       parent: 2
   - uid: 7179
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,24.5
       parent: 2
   - uid: 7180
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,25.5
       parent: 2
   - uid: 7181
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,26.5
       parent: 2
   - uid: 7182
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,27.5
       parent: 2
   - uid: 7183
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,28.5
       parent: 2
   - uid: 7184
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,29.5
       parent: 2
   - uid: 7199
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 5.5,36.5
       parent: 2
   - uid: 7200
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,36.5
       parent: 2
   - uid: 7201
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,36.5
       parent: 2
   - uid: 7202
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,36.5
       parent: 2
   - uid: 7203
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,36.5
       parent: 2
   - uid: 7204
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,36.5
       parent: 2
   - uid: 7205
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,36.5
       parent: 2
   - uid: 7206
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,35.5
       parent: 2
   - uid: 7228
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,32.5
       parent: 2
   - uid: 7229
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 11.5,31.5
       parent: 2
   - uid: 7231
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 10.5,30.5
       parent: 2
   - uid: 7233
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,33.5
       parent: 2
   - uid: 7234
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,32.5
       parent: 2
   - uid: 7235
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,31.5
       parent: 2
   - uid: 7237
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,30.5
       parent: 2
   - uid: 14807
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 14719
   - uid: 14808
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,0.5
       parent: 14719
   - uid: 14809
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 14719
   - uid: 14810
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 14719
   - uid: 14811
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 14719
   - uid: 14812
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 14719
   - uid: 14813
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 14719
   - uid: 14814
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 14719
   - uid: 14815
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 14719
   - uid: 14816
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-0.5
       parent: 14719
   - uid: 14817
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 14719
   - uid: 14818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 14719
   - uid: 14819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,1.5
       parent: 14719
   - uid: 14820
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 14719
   - uid: 14821
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 14719
   - uid: 14822
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
@@ -118693,106 +108452,76 @@ entities:
   entities:
   - uid: 135
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-23.5
       parent: 2
   - uid: 861
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-21.5
       parent: 2
   - uid: 862
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-21.5
       parent: 2
   - uid: 864
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-21.5
       parent: 2
   - uid: 865
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-21.5
       parent: 2
   - uid: 866
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-22.5
       parent: 2
   - uid: 867
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-23.5
       parent: 2
   - uid: 868
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-24.5
       parent: 2
   - uid: 869
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-25.5
       parent: 2
   - uid: 870
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-25.5
       parent: 2
   - uid: 871
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-25.5
       parent: 2
   - uid: 872
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -13.5,-25.5
       parent: 2
   - uid: 873
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-25.5
       parent: 2
   - uid: 874
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-24.5
       parent: 2
   - uid: 875
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-22.5
       parent: 2
@@ -118800,1681 +108529,1201 @@ entities:
   entities:
   - uid: 6
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
   - uid: 7
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
   - uid: 8
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
   - uid: 10
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-2.5
       parent: 2
   - uid: 11
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
   - uid: 12
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-0.5
       parent: 2
   - uid: 13
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,1.5
       parent: 2
   - uid: 14
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,2.5
       parent: 2
   - uid: 15
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,3.5
       parent: 2
   - uid: 16
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,3.5
       parent: 2
   - uid: 17
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,3.5
       parent: 2
   - uid: 18
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,3.5
       parent: 2
   - uid: 19
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,3.5
       parent: 2
   - uid: 20
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,3.5
       parent: 2
   - uid: 21
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,2.5
       parent: 2
   - uid: 22
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,1.5
       parent: 2
   - uid: 23
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,0.5
       parent: 2
   - uid: 24
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-0.5
       parent: 2
   - uid: 25
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
   - uid: 26
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,4.5
       parent: 2
   - uid: 27
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,5.5
       parent: 2
   - uid: 28
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,6.5
       parent: 2
   - uid: 29
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,7.5
       parent: 2
   - uid: 30
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,7.5
       parent: 2
   - uid: 31
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,8.5
       parent: 2
   - uid: 32
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,8.5
       parent: 2
   - uid: 33
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 2.5,8.5
       parent: 2
   - uid: 34
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,8.5
       parent: 2
   - uid: 35
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,6.5
       parent: 2
   - uid: 37
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,7.5
       parent: 2
   - uid: 38
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,7.5
       parent: 2
   - uid: 39
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,7.5
       parent: 2
   - uid: 40
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,7.5
       parent: 2
   - uid: 41
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,7.5
       parent: 2
   - uid: 42
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,6.5
       parent: 2
   - uid: 44
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,3.5
       parent: 2
   - uid: 45
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,2.5
       parent: 2
   - uid: 46
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,1.5
       parent: 2
   - uid: 47
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,0.5
       parent: 2
   - uid: 49
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
   - uid: 55
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
   - uid: 60
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
   - uid: 62
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,-3.5
       parent: 2
   - uid: 63
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-2.5
       parent: 2
   - uid: 64
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
   - uid: 65
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,-0.5
       parent: 2
   - uid: 66
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,0.5
       parent: 2
   - uid: 67
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,1.5
       parent: 2
   - uid: 68
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 9.5,2.5
       parent: 2
   - uid: 69
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,2.5
       parent: 2
   - uid: 70
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,2.5
       parent: 2
   - uid: 73
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,2.5
       parent: 2
   - uid: 114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-9.5
       parent: 2
   - uid: 115
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-9.5
       parent: 2
   - uid: 116
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 1.5,-9.5
       parent: 2
   - uid: 123
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-10.5
       parent: 2
   - uid: 124
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-11.5
       parent: 2
   - uid: 125
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-11.5
       parent: 2
   - uid: 126
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-12.5
       parent: 2
   - uid: 127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-13.5
       parent: 2
   - uid: 128
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,-14.5
       parent: 2
   - uid: 129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-10.5
       parent: 2
   - uid: 130
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-11.5
       parent: 2
   - uid: 131
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-12.5
       parent: 2
   - uid: 132
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-13.5
       parent: 2
   - uid: 133
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 4.5,-14.5
       parent: 2
   - uid: 136
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
   - uid: 138
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 3.5,-15.5
       parent: 2
   - uid: 220
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-8.5
       parent: 2
   - uid: 235
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,5.5
       parent: 2
   - uid: 241
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 6.5,2.5
       parent: 2
   - uid: 250
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-2.5
       parent: 2
   - uid: 251
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-9.5
       parent: 2
   - uid: 252
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-8.5
       parent: 2
   - uid: 254
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-11.5
       parent: 2
   - uid: 256
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-14.5
       parent: 2
   - uid: 258
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-2.5
       parent: 2
   - uid: 259
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-2.5
       parent: 2
   - uid: 260
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-3.5
       parent: 2
   - uid: 261
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-4.5
       parent: 2
   - uid: 262
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-5.5
       parent: 2
   - uid: 263
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-5.5
       parent: 2
   - uid: 264
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-5.5
       parent: 2
   - uid: 265
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-6.5
       parent: 2
   - uid: 266
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-8.5
       parent: 2
   - uid: 269
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-9.5
       parent: 2
   - uid: 270
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-8.5
       parent: 2
   - uid: 271
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-14.5
       parent: 2
   - uid: 272
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-10.5
       parent: 2
   - uid: 273
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-11.5
       parent: 2
   - uid: 274
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-14.5
       parent: 2
   - uid: 275
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-11.5
       parent: 2
   - uid: 276
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-2.5
       parent: 2
   - uid: 277
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-2.5
       parent: 2
   - uid: 278
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-14.5
       parent: 2
   - uid: 281
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-12.5
       parent: 2
   - uid: 283
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-5.5
       parent: 2
   - uid: 284
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-5.5
       parent: 2
   - uid: 286
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-8.5
       parent: 2
   - uid: 287
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-12.5
       parent: 2
   - uid: 288
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-2.5
       parent: 2
   - uid: 289
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-2.5
       parent: 2
   - uid: 290
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-2.5
       parent: 2
   - uid: 291
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-3.5
       parent: 2
   - uid: 292
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-4.5
       parent: 2
   - uid: 293
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-5.5
       parent: 2
   - uid: 294
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-7.5
       parent: 2
   - uid: 295
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-9.5
       parent: 2
   - uid: 297
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-11.5
       parent: 2
   - uid: 298
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-11.5
       parent: 2
   - uid: 299
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-10.5
       parent: 2
   - uid: 300
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-8.5
       parent: 2
   - uid: 301
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-8.5
       parent: 2
   - uid: 302
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-13.5
       parent: 2
   - uid: 304
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-11.5
       parent: 2
   - uid: 307
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 13.5,-14.5
       parent: 2
   - uid: 308
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 21.5,-11.5
       parent: 2
   - uid: 309
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 15.5,-11.5
       parent: 2
   - uid: 312
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 22.5,-14.5
       parent: 2
   - uid: 313
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 18.5,-14.5
       parent: 2
   - uid: 315
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-14.5
       parent: 2
   - uid: 316
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 20.5,-14.5
       parent: 2
   - uid: 317
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-14.5
       parent: 2
   - uid: 318
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-12.5
       parent: 2
   - uid: 320
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 19.5,-8.5
       parent: 2
   - uid: 322
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-8.5
       parent: 2
   - uid: 324
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 16.5,-12.5
       parent: 2
   - uid: 326
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-17.5
       parent: 2
   - uid: 433
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-8.5
       parent: 2
   - uid: 439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-10.5
       parent: 2
   - uid: 440
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-15.5
       parent: 2
   - uid: 445
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-11.5
       parent: 2
   - uid: 449
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-9.5
       parent: 2
   - uid: 451
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-7.5
       parent: 2
   - uid: 453
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-10.5
       parent: 2
   - uid: 454
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-10.5
       parent: 2
   - uid: 460
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-9.5
       parent: 2
   - uid: 462
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-5.5
       parent: 2
   - uid: 465
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-1.5
       parent: 2
   - uid: 466
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-4.5
       parent: 2
   - uid: 467
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
   - uid: 554
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,16.5
       parent: 2
   - uid: 559
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,-1.5
       parent: 2
   - uid: 560
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-3.5
       parent: 2
   - uid: 561
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-2.5
       parent: 2
   - uid: 563
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-5.5
       parent: 2
   - uid: 584
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,13.5
       parent: 2
   - uid: 589
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-17.5
       parent: 2
   - uid: 600
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-15.5
       parent: 2
   - uid: 601
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -11.5,-16.5
       parent: 2
   - uid: 755
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -12.5,-14.5
       parent: 2
   - uid: 771
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-12.5
       parent: 2
   - uid: 772
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-13.5
       parent: 2
   - uid: 773
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-14.5
       parent: 2
   - uid: 774
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-15.5
       parent: 2
   - uid: 778
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-13.5
       parent: 2
   - uid: 779
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-14.5
       parent: 2
   - uid: 780
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-15.5
       parent: 2
   - uid: 781
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-16.5
       parent: 2
   - uid: 784
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-17.5
       parent: 2
   - uid: 785
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-16.5
       parent: 2
   - uid: 814
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-18.5
       parent: 2
   - uid: 818
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-18.5
       parent: 2
   - uid: 819
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-18.5
       parent: 2
   - uid: 820
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -18.5,-15.5
       parent: 2
   - uid: 822
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -17.5,-14.5
       parent: 2
   - uid: 927
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -16.5,-14.5
       parent: 2
   - uid: 931
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,-20.5
       parent: 2
   - uid: 933
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-19.5
       parent: 2
   - uid: 934
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -5.5,-20.5
       parent: 2
   - uid: 936
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-18.5
       parent: 2
   - uid: 937
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-20.5
       parent: 2
   - uid: 1042
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-20.5
       parent: 2
   - uid: 1067
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,-4.5
       parent: 2
   - uid: 1068
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-4.5
       parent: 2
   - uid: 1069
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -21.5,-2.5
       parent: 2
   - uid: 1127
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,3.5
       parent: 2
   - uid: 1133
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -22.5,1.5
       parent: 2
   - uid: 1142
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,3.5
       parent: 2
   - uid: 1143
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,3.5
       parent: 2
   - uid: 1222
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-19.5
       parent: 2
   - uid: 1859
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,-27.5
       parent: 2
   - uid: 1934
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-0.5
       parent: 2
   - uid: 2462
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-24.5
       parent: 2
   - uid: 2508
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,-25.5
       parent: 2
   - uid: 2509
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-25.5
       parent: 2
   - uid: 2740
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-38.5
       parent: 2
   - uid: 2891
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-32.5
       parent: 2
   - uid: 2911
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-37.5
       parent: 2
   - uid: 2912
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-38.5
       parent: 2
   - uid: 2914
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-34.5
       parent: 2
   - uid: 2915
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-32.5
       parent: 2
   - uid: 2916
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -6.5,-32.5
       parent: 2
   - uid: 3405
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,19.5
       parent: 2
   - uid: 4668
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 0.5,4.5
       parent: 2
   - uid: 5291
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 17.5,-4.5
       parent: 2
   - uid: 7439
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -0.5,15.5
       parent: 2
   - uid: 7974
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 29.5,29.5
       parent: 2
   - uid: 8114
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,11.5
       parent: 2
   - uid: 8321
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-18.5
       parent: 2
   - uid: 8722
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-26.5
       parent: 2
   - uid: 9175
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-24.5
       parent: 2
   - uid: 9191
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,2.5
       parent: 2
   - uid: 9232
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-25.5
       parent: 2
   - uid: 9555
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-27.5
       parent: 2
   - uid: 9583
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-25.5
       parent: 2
   - uid: 9588
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-27.5
       parent: 2
   - uid: 9670
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-27.5
       parent: 2
   - uid: 10024
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-24.5
       parent: 2
   - uid: 10401
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-24.5
       parent: 2
   - uid: 10911
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -1.5,-18.5
       parent: 2
   - uid: 11042
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,-28.5
       parent: 2
   - uid: 11667
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -32.5,-28.5
       parent: 2
   - uid: 11737
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -34.5,-28.5
       parent: 2
   - uid: 11766
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -35.5,-28.5
       parent: 2
   - uid: 12029
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,10.5
       parent: 2
   - uid: 12544
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-16.5
       parent: 2
   - uid: 12579
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -33.5,10.5
       parent: 2
   - uid: 12629
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,8.5
       parent: 2
   - uid: 12630
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,9.5
       parent: 2
   - uid: 12631
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,10.5
       parent: 2
   - uid: 12633
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,12.5
       parent: 2
   - uid: 12634
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,13.5
       parent: 2
   - uid: 12635
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -29.5,14.5
       parent: 2
   - uid: 12636
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,14.5
       parent: 2
   - uid: 12637
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -27.5,14.5
       parent: 2
   - uid: 12638
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -26.5,14.5
       parent: 2
   - uid: 12639
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,14.5
       parent: 2
   - uid: 12640
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,14.5
       parent: 2
   - uid: 12641
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,13.5
       parent: 2
   - uid: 12642
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,9.5
       parent: 2
   - uid: 12643
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -24.5,8.5
       parent: 2
   - uid: 12644
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,8.5
       parent: 2
   - uid: 12645
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -28.5,8.5
       parent: 2
   - uid: 14532
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -14.5,-7.5
       parent: 2
   - uid: 14660
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -54.5,5.5
       parent: 2
   - uid: 14691
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -15.5,-5.5
       parent: 2
   - uid: 14929
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -23.5,4.5
       parent: 2
   - uid: 15336
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,-20.5
       parent: 2
   - uid: 15623
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 14.5,-2.5
       parent: 2
@@ -120743,120 +109992,86 @@ entities:
   entities:
   - uid: 1169
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 7.5,-15.5
       parent: 2
   - uid: 1834
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -25.5,-4.5
       parent: 2
   - uid: 1835
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -30.5,-1.5
       parent: 2
   - uid: 1943
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -31.5,-0.5
       parent: 2
   - uid: 1993
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 8.5,-14.5
       parent: 2
   - uid: 2321
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-4.5
       parent: 2
   - uid: 2919
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -69.5,-9.5
       parent: 2
   - uid: 7134
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 26.5,32.5
       parent: 2
   - uid: 8085
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 30.5,31.5
       parent: 2
   - uid: 8765
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: 27.5,33.5
       parent: 2
   - uid: 9170
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -43.5,4.5
       parent: 2
   - uid: 11115
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-37.5
       parent: 2
   - uid: 11116
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-35.5
       parent: 2
   - uid: 11117
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -9.5,-34.5
       parent: 2
   - uid: 11118
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -4.5,-33.5
       parent: 2
   - uid: 11129
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -8.5,-34.5
       parent: 2
   - uid: 11169
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -7.5,-33.5
       parent: 2
@@ -121137,15 +110352,10 @@ entities:
       parent: 2
 - proto: WarningWaste
   entities:
-  - uid: 3259
+  - uid: 10294
     components:
     - type: Transform
       pos: -37.5,43.5
-      parent: 2
-  - uid: 3563
-    components:
-    - type: Transform
-      pos: -41.5,43.5
       parent: 2
 - proto: WarpPointBombing
   entities:
@@ -121265,11 +110475,6 @@ entities:
       joinedGrid: 2
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 6896
-    components:
-    - type: Transform
-      pos: -13.5,0.5
-      parent: 2
   - uid: 7390
     components:
     - type: Transform
@@ -121329,8 +110534,6 @@ entities:
   entities:
   - uid: 1596
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 1535
     - type: Physics
@@ -121350,20 +110553,18 @@ entities:
     - type: Transform
       pos: 28.427675,31.71158
       parent: 2
-- proto: WeaponPistolN1984
+- proto: WeaponPistolViper
   entities:
-  - uid: 3081
+  - uid: 461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 34.27308,46.425922
+      pos: 34.44175,46.436523
       parent: 2
 - proto: WeaponRevolverDeckard
   entities:
   - uid: 7378
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 7374
     - type: Physics
@@ -121467,19 +110668,10 @@ entities:
     - type: Transform
       pos: 35.421516,46.496235
       parent: 2
-- proto: WebBed
-  entities:
-  - uid: 408
-    components:
-    - type: Transform
-      pos: 15.5,-12.5
-      parent: 2
 - proto: WelderIndustrial
   entities:
   - uid: 2351
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3226
     - type: Physics
@@ -121487,8 +110679,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 2394
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12157
     - type: Physics
@@ -121496,8 +110686,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 2412
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 12163
     - type: Physics
@@ -121505,8 +110693,6 @@ entities:
     - type: InsideEntityStorage
   - uid: 3566
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 3565
     - type: Physics
@@ -122451,15 +111637,11 @@ entities:
   entities:
   - uid: 53
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -2.5,0.5
       parent: 2
   - uid: 54
     components:
-    - type: MetaData
-      flags: PvsPriority
     - type: Transform
       pos: -3.5,3.5
       parent: 2
@@ -123105,8 +112287,6 @@ entities:
   entities:
   - uid: 13216
     components:
-    - type: MetaData
-      flags: InContainer
     - type: Transform
       parent: 13151
     - type: Physics

--- a/Resources/Maps/corvax_outpost.yml
+++ b/Resources/Maps/corvax_outpost.yml
@@ -48734,7 +48734,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -46.5,24.5
       parent: 2
-- proto: Firelock
+- proto: FirelockGlass
   entities:
   - uid: 101
     components:


### PR DESCRIPTION
## Описание PR
Правки

**Изменения**
:cl: TheShuEd, Jeb
- add: Химка получила центрифугу, электролизную установку. В хранилище генератор заменен на конденсатор газов.
- add: Глава персонала получил принтер документов.
- fix: Починена разгерма в прибытии.
- fix: Игроки раундстартом и лейтджоином больше не будут появляться запертыми в вирусологии. Дормы получили больше криокапсул.
- tweak: Jeb сделал жизнь атмосов еще веселее.
- tweak: Все пожарные шлюзы теперь прозрачные.
- tweak: В пермабриг доступ заменен с брига на СБ.
- tweak: ДАМ удален.