### PR TITLE
Возврат хайджека

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -34,7 +34,7 @@
   weights:
     EscapeShuttleObjective: 1
     DieObjective: 0.05
-    #HijackShuttleObjective: 0.02
+    HijackShuttleObjective: 0.02 #Corvax-MRP
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSocial

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -68,19 +68,19 @@
       - StealCondition
   - type: DieCondition
 
-#- type: entity
-#  noSpawn: true
-#  parent: [BaseTraitorObjective, BaseLivingObjective]
-#  id: HijackShuttleObjective
-#  name: Hijack emergency shuttle
-#  description: Leave on the shuttle free and clear of the loyal Nanotrasen crew on board. Use ANY methods available to you. Syndicate agents, Nanotrasen enemies, and handcuffed hostages may remain alive on the shuttle. Ignore assistance from anyone other than a support agent.
-#  components:
-#    - type: Objective
-#      difficulty: 5 # insane, default config max difficulty
-#      icon:
-#        sprite: Objects/Tools/emag.rsi
-#        state: icon
-#    - type: HijackShuttleCondition
+- type: entity
+  noSpawn: true
+  parent: [BaseTraitorObjective, BaseLivingObjective]
+  id: HijackShuttleObjective #Corvax-MRP
+  name: Hijack emergency shuttle
+  description: Leave on the shuttle free and clear of the loyal Nanotrasen crew on board. Use ANY methods available to you. Syndicate agents, Nanotrasen enemies, and handcuffed hostages may remain alive on the shuttle. Ignore assistance from anyone other than a support agent.
+  components:
+    - type: Objective
+      difficulty: 5 # insane, default config max difficulty
+      icon:
+        sprite: Objects/Tools/emag.rsi
+        state: icon
+    - type: HijackShuttleCondition
 
 # kill
 


### PR DESCRIPTION
Возврат хайджека

## Описание PR
Возврат цели на угон эвакуационного шаттла. Цель была закомментирована Wizard и перестала выдаваться агентам. Кроме того, она стала и более сложной к выполнению, поскольку емаг эвака теперь сделать нельзя и хайджекеру нужно приложить больше усилий. Шанс выпадения также, как и был - 0.02, ниже, чем у славной смерти. Переводы цели не были удалены.

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно просмотрел все свои изменения и багов в них не нашёл.

**Изменения**
- tweak: Цель на хайджек снова выдаётся агентам Синдиката.