### PR TITLE
Автоматизация ОБР

### DIFF
--- a/Resources/Prototypes/Corvax/Markers/Spawners/ert.yml
+++ b/Resources/Prototypes/Corvax/Markers/Spawners/ert.yml
@@ -1,0 +1,96 @@
+- type: entity
+  id: BaseERTSpawner
+  name: one-time signal ERT spawner
+  abstract: true
+  parent: MarkerBase
+  components:
+  - type: DeviceLinkSink
+    ports:
+    - Trigger  
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: TriggerOnSignal
+  - type: DeleteOnTrigger
+
+- type: entity
+  id: ERTSpawnerLeader
+  parent: BaseERTSpawner
+  suffix: Leader
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Markers/jobs.rsi
+        state: ertleader
+  - type: SpawnOnTrigger
+    proto: RandomHumanoidSpawnerERTLeader
+
+- type: entity
+  id: ERTSpawnerJanitor
+  parent: BaseERTSpawner
+  suffix: Janitor
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Markers/jobs.rsi
+        state: ertjanitor
+  - type: SpawnOnTrigger
+    proto: RandomHumanoidSpawnerERTJanitor
+
+- type: entity
+  id: ERTSpawnerEngineering
+  parent: BaseERTSpawner
+  suffix: Engineering
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Markers/jobs.rsi
+        state: ertengineer
+  - type: SpawnOnTrigger
+    proto: RandomHumanoidSpawnerERTEngineer
+
+- type: entity
+  id: ERTSpawnerSrcurity
+  parent: BaseERTSpawner
+  suffix: Security
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Markers/jobs.rsi
+        state: ertsecurity
+  - type: SpawnOnTrigger
+    proto: RandomHumanoidSpawnerERTSecurity
+
+- type: entity
+  id: ERTSpawnerMedical
+  parent: BaseERTSpawner
+  suffix: Medical
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Markers/jobs.rsi
+        state: ertmedical
+  - type: SpawnOnTrigger
+    proto: RandomHumanoidSpawnerERTMedical
+
+#CBURN
+
+- type: entity
+  id: ERTSpawnerCBURN
+  name: one-time signal CBURN spawner
+  parent: BaseERTSpawner
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Markers/jobs.rsi
+        state: cburn
+  - type: SpawnOnTrigger
+    proto: RandomHumanoidSpawnerCBURNUnit


### PR DESCRIPTION
## Описание PR
Добавлены одноразовые маркеры спавна ОБР, срабатывающие по сигналу. Их необходимо замаппить на СЦК, после чего админы или игроки на ОЦК смогут без доступа к педалям, вызвать ОБР или РХБЗЗ гостроли по нажатии на одну кнопку.

KMIN, ваш заказ.

**Медиа**

https://github.com/space-syndicate/space-station-14/assets/96445749/c82680c4-866a-4cba-b886-d44bf2bb662d



**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.