### PR TITLE
Revert "Enable worldgen"

### DIFF
--- a/Resources/ConfigPresets/Corvax/common.toml
+++ b/Resources/ConfigPresets/Corvax/common.toml
@@ -23,6 +23,3 @@ rules_header = "ui-rules-header-corvax"
 
 [discord]
 rich_main_icon_id = "corvax"
-
-[worldgen]
-enabled = true


### PR DESCRIPTION
 ## Описание PR
Реверт space-syndicate/space-station-14#2050

Создаёт очень лютое месиво из гридов, кои к чёрту никому не упёрлись. От них нет особого смысла, но при этом в глаза бросается очень сильно. Особенно эта проблема вставляет палки при маппинге, буквально засирая список гридов и вызывая нехилые лаги. 

**Медиа**
![Screenshot_2024-04-27-14-26-21-339_com discord-edit](https://github.com/space-syndicate/space-station-14/assets/75203942/38753277-3f7b-4dff-81eb-68a5c40ec3ee)







