### PR TITLE
Убрана цель на содержание опасного существа

### DIFF
--- a/Resources/Prototypes/Corvax/Objectives/goals.yml
+++ b/Resources/Prototypes/Corvax/Objectives/goals.yml
@@ -27,9 +27,5 @@
   text: station-goal-mining-outpost
 
 - type: stationGoal
-  id: StationGoalContaintment
-  text: station-goal-containment
-
-- type: stationGoal
   id: StationGoalTesla
   text: station-goal-tesla


### PR DESCRIPTION
После обновы оффов поймать существо стало почти невозможно с текущими механиками - они вырываются с стульев, из ящиков и так далее.