### PR TITLE
Fuck Fuckrules

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -25,8 +25,6 @@
     - gcf
     - gc
     - gc_mode
-    - cvar
-    - fuckrules
     - midipanic
     - replay_recording_start
     - replay_recording_stop
@@ -73,6 +71,8 @@
     - detachent
     - localdelete
     - fullstatereset
+    - cvar
+    - fuckrules
 
 - Flags: MAPPING
   Commands:


### PR DESCRIPTION
Fuckrules позволяет обойти единственный доступный способ задерживать набегаторов, если у тебя нет модерских педалей на сервере. Фриз, телепортация на арену и гиб с недавних пор перестали работать нормально. А цварники игрокам и так не нужны.