### PR TITLE
Поменять владельца диска ядерной авторизации со станции на капитана.

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -292,4 +292,4 @@
   - type: NotCommandRequirement
   - type: StealCondition
     stealGroup: NukeDisk
-    owner: objective-condition-steal-station
+    owner: job-name-captain


### PR DESCRIPTION
## Описание PR
Данный PR меняет владельца диска ядерной авторизации со станции на капитана.

Причина:
По правилам проекта у нас цель на диск не является исключительной и не имеет никаких послаблений. Точно так же, у нас по правилам разрешено гибать владельцев хайрисков. Данное изменение нужно для того, чтобы избавиться от противоречий и недосказанностей, а так же соответствовать правилам проекта и логике.

:cl: nekosich
- change: Владельцем диска ядерной авторизации теперь является не станция, а капитан