### PR TITLE
Убирает первосортное мясо корги из спавна на шаттле странствующих поваров.

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
@@ -763,15 +763,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: FoodMeatCorgi
-  entities:
-  - uid: 27
-    components:
-    - type: Transform
-      parent: 10
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: FoodMeatDragon
   entities:
   - uid: 96


### PR DESCRIPTION
## Описание PR
Данный PR удаляет мясо Иана из пулла спавна на шаттле странствующих поваров. Это нужно ради баланса, так как мясо Иана является хайриском и целью для кражи.

**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.

**Изменения**
:cl: nekosich
- remove: Убрано мясо Иана у странствующих поваров. 

