### PR TITLE
Fix health examinable & bloodstream locale

### DIFF
--- a/Resources/Locale/ru-RU/bloodstream/bloodstream.ftl
+++ b/Resources/Locale/ru-RU/bloodstream/bloodstream.ftl
@@ -1,4 +1,5 @@
-bloodstream-component-looks-pale = [color=bisque]{ CAPITALIZE($target) } выглядит бледно.[/color]
-bloodstream-component-bleeding = [color=red]{ CAPITALIZE($target) } истекает кровью.[/color]
-bloodstream-component-profusely-bleeding = [color=crimson]{ CAPITALIZE($target) } обильно истекает кровью![/color]
+bloodstream-component-looks-pale = [color=bisque]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BASIC($target, "выглядят", "выглядит")} бледно.[/color]
+bloodstream-component-bleeding = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BASIC($target, "истекают", "истекает")} кровью.[/color]
+bloodstream-component-profusely-bleeding = [color=crimson]{CAPITALIZE(SUBJECT($target))} обильно {CONJUGATE-BASIC($target, "истекают", "истекает")} кровью![/color]
+
 bloodstream-component-wounds-cauterized = С болью вы ощущаете, как ваши раны прижигаются!

--- a/Resources/Locale/ru-RU/health-examinable/health-examinable-carbon.ftl
+++ b/Resources/Locale/ru-RU/health-examinable/health-examinable-carbon.ftl
@@ -2,12 +2,12 @@ health-examinable-carbon-none = Видимые повреждения тела �
 
 health-examinable-carbon-Blunt-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } небольшие ушибы на теле.[/color]
 health-examinable-carbon-Blunt-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } серьёзные ушибы на теле![/color]
-health-examinable-carbon-Blunt-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } тело полностью покрыто язвами![/color]
+health-examinable-carbon-Blunt-75 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } сильные ушибы по всему телу![/color]
 
 health-examinable-carbon-Slash-10 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } несколько лёгких порезов.[/color]
 health-examinable-carbon-Slash-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } серьёзные порезы на теле.[/color]
 health-examinable-carbon-Slash-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } множество сильных порезов![/color]
-health-examinable-carbon-Slash-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } тело полностью изувечено![/color]
+health-examinable-carbon-Slash-75 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } множество глубоких порезов на теле![/color]
 
 health-examinable-carbon-Piercing-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } проникающие ранения на теле![/color]
 

--- a/Resources/Locale/ru-RU/health-examinable/health-examinable-carbon.ftl
+++ b/Resources/Locale/ru-RU/health-examinable/health-examinable-carbon.ftl
@@ -1,19 +1,26 @@
 health-examinable-carbon-none = Видимые повреждения тела отсутствуют.
-health-examinable-carbon-Blunt-25 = [color=red]{ CAPITALIZE($target) } имеет небольшие ушибы на теле.[/color]
-health-examinable-carbon-Blunt-50 = [color=crimson]{ CAPITALIZE($target) } имеет серьёзные ушибы на теле![/color]
-health-examinable-carbon-Blunt-75 = [color=crimson]{ CAPITALIZE($target) } имеет сильные ушибы по всему телу![/color]
-health-examinable-carbon-Slash-10 = [color=red]{ CAPITALIZE($target) } имеет несколько лёгких порезов.[/color]
-health-examinable-carbon-Slash-25 = [color=red]{ CAPITALIZE($target) } имеет серьёзные порезы на теле.[/color]
-health-examinable-carbon-Slash-50 = [color=crimson]{ CAPITALIZE($target) } имеет множество сильных порезов![/color]
-health-examinable-carbon-Slash-75 = [color=crimson]{ CAPITALIZE($target) } имеет множество глубоких порезов на теле![/color]
-health-examinable-carbon-Piercing-50 = [color=crimson]{ CAPITALIZE($target) } имеет проникающие ранения на теле![/color]
-health-examinable-carbon-Heat-25 = [color=orange]{ CAPITALIZE($target) } имеет лёгкие ожоги на теле.[/color]
-health-examinable-carbon-Heat-50 = [color=orange]{ CAPITALIZE($target) } имеет сильные ожоги на теле.[/color]
-health-examinable-carbon-Heat-75 = [color=orange]{ CAPITALIZE($target) } имеет ожоги третьей степени на теле![/color]
-health-examinable-carbon-Shock-50 = [color=lightgoldenrodyellow]{ CAPITALIZE($target) } имеет следы поражения током по всему телу![/color]
-health-examinable-carbon-Cold-25 = [color=lightblue]{ CAPITALIZE($target) } имеет лёгкие обморожения на теле.[/color]
-health-examinable-carbon-Cold-50 = [color=lightblue]{ CAPITALIZE($target) } имеет сильные обморожения на теле.[/color]
-health-examinable-carbon-Cold-75 = [color=lightblue]{ CAPITALIZE($target) } имеет обморожения третьей степени на теле![/color]
-health-examinable-carbon-Caustic-25 = [color=yellowgreen]{ CAPITALIZE($target) } имеет лёгкие химические ожоги.[/color]
-health-examinable-carbon-Caustic-50 = [color=yellowgreen]{ CAPITALIZE($target) } имеет химические ожоги на теле.[/color]
-health-examinable-carbon-Caustic-75 = [color=yellowgreen]{ CAPITALIZE($target) } имеет сильные химические ожоги по всей поверхности тела![/color]
+
+health-examinable-carbon-Blunt-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } небольшие ушибы на теле.[/color]
+health-examinable-carbon-Blunt-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } серьёзные ушибы на теле![/color]
+health-examinable-carbon-Blunt-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } тело полностью покрыто язвами![/color]
+
+health-examinable-carbon-Slash-10 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } несколько лёгких порезов.[/color]
+health-examinable-carbon-Slash-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } серьёзные порезы на теле.[/color]
+health-examinable-carbon-Slash-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } множество сильных порезов![/color]
+health-examinable-carbon-Slash-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } тело полностью полностью изувечено![/color]
+
+health-examinable-carbon-Piercing-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } проникающие ранения на теле![/color]
+
+health-examinable-carbon-Heat-25 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } лёгкие ожоги на теле.[/color]
+health-examinable-carbon-Heat-50 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } сильные ожоги на теле.[/color]
+health-examinable-carbon-Heat-75 = [color=orange]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } ожоги третьей степени на теле![/color]
+
+health-examinable-carbon-Shock-50 = [color=lightgoldenrodyellow]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } следы поражения током по всему телу![/color]
+
+health-examinable-carbon-Cold-25 = [color=lightblue]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } лёгкие обморожения на теле.[/color]
+health-examinable-carbon-Cold-50 = [color=lightblue]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } сильные обморожения на теле.[/color]
+health-examinable-carbon-Cold-75 = [color=lightblue]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } обморожения третьей степени на теле![/color]
+
+health-examinable-carbon-Caustic-25 = [color=yellowgreen]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } лёгкие химические ожоги.[/color]
+health-examinable-carbon-Caustic-50 = [color=yellowgreen]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } химические ожоги на теле.[/color]
+health-examinable-carbon-Caustic-75 = [color=yellowgreen]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } сильные химические ожоги по всей поверхности тела![/color]

--- a/Resources/Locale/ru-RU/health-examinable/health-examinable-carbon.ftl
+++ b/Resources/Locale/ru-RU/health-examinable/health-examinable-carbon.ftl
@@ -7,7 +7,7 @@ health-examinable-carbon-Blunt-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target
 health-examinable-carbon-Slash-10 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } несколько лёгких порезов.[/color]
 health-examinable-carbon-Slash-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } серьёзные порезы на теле.[/color]
 health-examinable-carbon-Slash-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } множество сильных порезов![/color]
-health-examinable-carbon-Slash-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } тело полностью полностью изувечено![/color]
+health-examinable-carbon-Slash-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } тело полностью изувечено![/color]
 
 health-examinable-carbon-Piercing-50 = [color=crimson]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } проникающие ранения на теле![/color]
 

--- a/Resources/Locale/ru-RU/health-examinable/health-examinable-silicon.ftl
+++ b/Resources/Locale/ru-RU/health-examinable/health-examinable-silicon.ftl
@@ -5,7 +5,7 @@ health-examinable-silicon-Blunt-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($targe
 health-examinable-silicon-Blunt-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси почти разваливается![/color]
 
 health-examinable-silicon-Slash-10 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } несколько царапин.[/color]
-health-examinable-silicon-Slash-25 = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } { CONJUGATE-HAVE($target) } серьёзные царапины![/color]
+health-examinable-silicon-Slash-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } серьёзные царапины![/color]
 health-examinable-silicon-Slash-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } покрытие шасси усыпано глубокими цапапинами![/color]
 health-examinable-silicon-Slash-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси полностю разодрано![/color]
 

--- a/Resources/Locale/ru-RU/health-examinable/health-examinable-silicon.ftl
+++ b/Resources/Locale/ru-RU/health-examinable/health-examinable-silicon.ftl
@@ -1,13 +1,18 @@
 health-examinable-silicon-none = Видимые повреждения корпуса отсутствуют.
-health-examinable-silicon-Blunt-25 = [color=red]{ CAPITALIZE($target) } имеет небольшие вмятины на шасси.[/color]
-health-examinable-silicon-Blunt-50 = [color=crimson]{ CAPITALIZE($target) } имеет серьёзные вмятины по всему шасси![/color]
-health-examinable-silicon-Blunt-75 = [color=crimson]Шасси { CAPITALIZE($target) } почти разваливается![/color]
-health-examinable-silicon-Slash-10 = [color=red]Шасси { CAPITALIZE($target) } имеет несколько царапин.[/color]
-health-examinable-silicon-Slash-25 = [color=red]Шасси { CAPITALIZE($target) } имеет серьёзные царапины по всему шасси![/color]
-health-examinable-silicon-Slash-50 = [color=crimson]Покрытие шасси { CAPITALIZE($target) } усыпано глубокими цапапинами![/color]
-health-examinable-silicon-Slash-75 = [color=crimson]Шасси { CAPITALIZE($target) } полностю разодрано![/color]
-health-examinable-silicon-Piercing-50 = [color=crimson]Шасси { CAPITALIZE($target) } усеяно глубокими отверстиями![/color]
-health-examinable-silicon-Heat-25 = [color=orange]Шасси { CAPITALIZE($target) } слегка закоптилось.[/color]
-health-examinable-silicon-Heat-50 = [color=orange]Шасси { CAPITALIZE($target) } немного оплавилось.[/color]
-health-examinable-silicon-Heat-75 = [color=orange]Шасси { CAPITALIZE($target) } частично расплавилось![/color]
-health-examinable-silicon-Shock-50 = [color=lightgoldenrodyellow]Микросхемы { CAPITALIZE($target) }, похоже, неплохо поджарились![/color]
+
+health-examinable-silicon-Blunt-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } небольшие вмятины на шасси.[/color]
+health-examinable-silicon-Blunt-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси имеет серьёзные вмятины![/color]
+health-examinable-silicon-Blunt-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси почти разваливается![/color]
+
+health-examinable-silicon-Slash-10 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } имеет несколько царапин.[/color]
+health-examinable-silicon-Slash-25 = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } имеет серьёзные царапины![/color]
+health-examinable-silicon-Slash-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } покрытие шасси усыпано глубокими цапапинами![/color]
+health-examinable-silicon-Slash-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси полностю разодрано![/color]
+
+health-examinable-silicon-Piercing-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси усеяно глубокими отверстиями![/color]
+
+health-examinable-silicon-Heat-25 = [color=orange]{ CAPITALIZE(POSS-ADJ($target)) } шасси слегка закоптилось.[/color]
+health-examinable-silicon-Heat-50 = [color=orange]{ CAPITALIZE(POSS-ADJ($target)) } шасси немного оплавилось.[/color]
+health-examinable-silicon-Heat-75 = [color=orange]{ CAPITALIZE(POSS-ADJ($target)) } шасси частично расплавилось![/color]
+
+health-examinable-silicon-Shock-50 = [color=lightgoldenrodyellow]{ CAPITALIZE(POSS-ADJ($target)) } микросхемы, похоже, неплохо поджарились![/color]

--- a/Resources/Locale/ru-RU/health-examinable/health-examinable-silicon.ftl
+++ b/Resources/Locale/ru-RU/health-examinable/health-examinable-silicon.ftl
@@ -4,8 +4,8 @@ health-examinable-silicon-Blunt-25 = [color=red]{ CAPITALIZE(SUBJECT($target)) }
 health-examinable-silicon-Blunt-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси имеет серьёзные вмятины![/color]
 health-examinable-silicon-Blunt-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси почти разваливается![/color]
 
-health-examinable-silicon-Slash-10 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } имеет несколько царапин.[/color]
-health-examinable-silicon-Slash-25 = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } имеет серьёзные царапины![/color]
+health-examinable-silicon-Slash-10 = [color=red]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } несколько царапин.[/color]
+health-examinable-silicon-Slash-25 = [color=red]{ CAPITALIZE(POSS-ADJ($target)) } { CONJUGATE-HAVE($target) } серьёзные царапины![/color]
 health-examinable-silicon-Slash-50 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } покрытие шасси усыпано глубокими цапапинами![/color]
 health-examinable-silicon-Slash-75 = [color=crimson]{ CAPITALIZE(POSS-ADJ($target)) } шасси полностю разодрано![/color]
 

--- a/Resources/Locale/ru-RU/robust-toolbox/_engine_lib.ftl
+++ b/Resources/Locale/ru-RU/robust-toolbox/_engine_lib.ftl
@@ -53,8 +53,8 @@ zzzz-conjugate-be =
 # Used internally by the CONJUGATE-HAVE() function.
 zzzz-conjugate-have =
     { GENDER($ent) ->
-        [epicene] have
-       *[other] has
+        [epicene] имеют
+       *[other] имеет
     }
 # Used internally by the CONJUGATE-BASIC() function.
 zzzz-conjugate-basic =


### PR DESCRIPTION
было переделано с использованием SUBJECT и CONJUGATE-HAVE (который тоже был локализирован)


![Screenshot_20240722_075859](https://github.com/user-attachments/assets/d4c08b0c-3743-40e9-b468-4f686f731198)
скриншот ниже устаревший, описание порезов было возвращено обратно
![Screenshot_20240722_080712](https://github.com/user-attachments/assets/bbc5d9b9-314a-4860-ab52-99cc6c1b749e)
![Screenshot_20240722_080149](https://github.com/user-attachments/assets/4e1f802a-4a66-4528-be2a-b8fe3325e447)

:cl:
- tweak: Улучшено описание урона и кровотечения.