### PR TITLE
Remove mining shuttle from corvax maps

### DIFF
--- a/Resources/Prototypes/Corvax/Maps/frame.yml
+++ b/Resources/Prototypes/Corvax/Maps/frame.yml
@@ -27,9 +27,6 @@
                 - type: TradeStation
               paths:
                 - /Maps/Shuttles/trading_outpost.yml
-            mining: !type:GridSpawnGroup
-              paths:
-              - /Maps/Shuttles/corvax_mining.yml
             # Spawn last
             ruins: !type:GridSpawnGroup
               hide: true

--- a/Resources/Prototypes/Corvax/Maps/silly.yml
+++ b/Resources/Prototypes/Corvax/Maps/silly.yml
@@ -29,9 +29,6 @@
                 - type: TradeStation
               paths:
                 - /Maps/Shuttles/trading_outpostcorvaxsilly.yml
-            mining: !type:GridSpawnGroup
-              paths:
-              - /Maps/Shuttles/mining_corvaxsilly.yml
             # Spawn last
             ruins: !type:GridSpawnGroup
               hide: true

--- a/Resources/Prototypes/Corvax/Maps/split.yml
+++ b/Resources/Prototypes/Corvax/Maps/split.yml
@@ -138,9 +138,6 @@
                 - type: TradeStation
               paths:
                 - /Maps/Shuttles/trading_outpost.yml
-            mining: !type:GridSpawnGroup
-              paths:
-              - /Maps/Shuttles/corvax_mining.yml
             # Spawn last
             ruins: !type:GridSpawnGroup
               hide: true


### PR DESCRIPTION
убрал шахтёрский шаттл со спавна в прототипах карт
along with https://github.com/space-wizards/space-station-14/pull/31333