### PR TITLE
Фикс работы с температурой консольной команды setmapatmos

### DIFF
--- a/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
+++ b/Content.Server/Atmos/Commands/SetMapAtmosCommand.cs
@@ -54,7 +54,7 @@ public sealed class AddMapAtmosCommand : LocalizedCommands
             return;
         }
 
-        var mix = new GasMixture(Atmospherics.CellVolume) {Temperature = Math.Min(temp, Atmospherics.TCMB)};
+        var mix = new GasMixture(Atmospherics.CellVolume) {Temperature = Math.Max(temp, Atmospherics.TCMB)};
         for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
         {
             if (args.Length == 3 + i)


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Теперь команда setmapatmos может выставлять атмосфере температуру из переданных аргументов.

## Почему / Баланс
Ранее команда выставляла при вызове атмосу температуру космоса по-умолчанию -  2.7F (даже если команда вызывалась на планетарной карте).

## Технические детали
1-line commit

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
[fix_setmapatmos_command.webm](https://github.com/user-attachments/assets/a47c2fc2-0379-46a0-94e2-8e836f1ccf85)

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [ ] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
нет
**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
