### PR TITLE
Удаление лимита времени для доступа к стартовым ролям.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -6,14 +6,14 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 3600 #1 hr
-    - !type:DepartmentTimeRequirement
-      department: Engineering
-      time: 36000 #10 hrs # Corvax-RoleTime
-      inverted: true # stop playing intern if you're good at engineering!
+    # - !type:DepartmentTimeRequirement
+      # department: Engineering
+      # time: 36000 #10 hrs # Corvax-RoleTime
+      # inverted: true # stop playing intern if you're good at engineering!
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering
-  canBeAntag: false
+  canBeAntag: true # Corvax-MRP: Available not only for newbies
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -3,15 +3,15 @@
   name: job-name-intern
   description: job-description-intern
   playTimeTracker: JobMedicalIntern
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 36000 #10 hrs # Corvax-RoleTime
-      inverted: true # stop playing intern if you're good at med!
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Medical
+      # time: 36000 #10 hrs # Corvax-RoleTime
+      # inverted: true # stop playing intern if you're good at med!
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine
-  canBeAntag: false
+  canBeAntag: true # Corvax-MRP: Available not only for newbies
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -3,15 +3,15 @@
   name: job-name-research-assistant
   description: job-description-research-assistant
   playTimeTracker: JobResearchAssistant
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Science
-      time: 36000 #10 hrs # Corvax-RoleTime
-      inverted: true # stop playing intern if you're good at science!
+  # requirements:
+    # - !type:DepartmentTimeRequirement
+      # department: Science
+      # time: 36000 #10 hrs # Corvax-RoleTime
+      # inverted: true # stop playing intern if you're good at science!
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science
-  canBeAntag: false
+  canBeAntag: true # Corvax-MRP: Available not only for newbies
   access:
   - Research
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -6,10 +6,10 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 36000 #10 hrs # Corvax-RoleTime
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 72000 #20 hrs # Corvax-RoleTime
-      inverted: true # stop playing intern if you're good at security!
+    # - !type:DepartmentTimeRequirement
+      # department: Security
+      # time: 72000 #20 hrs # Corvax-RoleTime
+      # inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Убрано максимальное требуемое время для игры на роли. Реализация согласно опроснику из Discord группы.
https://discord.com/channels/919301044784226385/1084254414388347001/1284248588842700991
Так же, в связи с удалением максимального требуемого времени, было приведено в соответствии с сервисным работником - каждый может стать антагонистом.
## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Пока проходил опрос мною было проверено по логам 736 аккаунтов, которые отмечались как "зашел впервые" с начала месяца. Только 27 из них фактически были новыми игроками. Остальные либо аккаунты пустышки, которые не заходили дальше лобби, после чего исчезали навсегда, либо набегаторы, либо твинк аккаунты. Так что не должно вызвать эффекта, что "у новичков отобрали роли". 

В крайнем случае, если вдруг случится так ожидаемый всеми "Вот щас точно попрут игроки, вот щас щас, вот почти", то ревертнуть не долго.
## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
* Убрано максимальное требуемое время для игры на роли. Больше нет ограничения.
* Добавлена возможность становиться антагонистом на "начинающих" ролях.

P.S. В данный момент до конца опроса осталось 23 часа, так что результаты могут вдруг магически измениться.
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
![image](https://github.com/user-attachments/assets/eb418a66-5f87-479e-9ea6-8dd0c74c3551)
