### PR TITLE
Revert "Удаление лимита времени для доступа к стартовым ролям."

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -6,14 +6,14 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 3600 #1 hr
-    # - !type:DepartmentTimeRequirement
-      # department: Engineering
-      # time: 36000 #10 hrs # Corvax-RoleTime
-      # inverted: true # stop playing intern if you're good at engineering!
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 36000 #10 hrs # Corvax-RoleTime
+      inverted: true # stop playing intern if you're good at engineering!
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering
-  canBeAntag: true # Corvax-MRP: Available not only for newbies
+  canBeAntag: false
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -3,15 +3,15 @@
   name: job-name-intern
   description: job-description-intern
   playTimeTracker: JobMedicalIntern
-  # requirements:
-    # - !type:DepartmentTimeRequirement
-      # department: Medical
-      # time: 36000 #10 hrs # Corvax-RoleTime
-      # inverted: true # stop playing intern if you're good at med!
+  requirements:
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 36000 #10 hrs # Corvax-RoleTime
+      inverted: true # stop playing intern if you're good at med!
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine
-  canBeAntag: true # Corvax-MRP: Available not only for newbies
+  canBeAntag: false
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -3,15 +3,15 @@
   name: job-name-research-assistant
   description: job-description-research-assistant
   playTimeTracker: JobResearchAssistant
-  # requirements:
-    # - !type:DepartmentTimeRequirement
-      # department: Science
-      # time: 36000 #10 hrs # Corvax-RoleTime
-      # inverted: true # stop playing intern if you're good at science!
+  requirements:
+    - !type:DepartmentTimeRequirement
+      department: Science
+      time: 36000 #10 hrs # Corvax-RoleTime
+      inverted: true # stop playing intern if you're good at science!
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science
-  canBeAntag: true # Corvax-MRP: Available not only for newbies
+  canBeAntag: false
   access:
   - Research
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -6,10 +6,10 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 36000 #10 hrs # Corvax-RoleTime
-    # - !type:DepartmentTimeRequirement
-      # department: Security
-      # time: 72000 #20 hrs # Corvax-RoleTime
-      # inverted: true # stop playing intern if you're good at security!
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 #20 hrs # Corvax-RoleTime
+      inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security


### PR DESCRIPTION
Reverts space-syndicate/space-station-14#2605
по предложению https://discord.com/channels/919301044784226385/1293968774617239605
цитата из предложения
> Из-за того, что на начальных ролях обычно играют новички, все старички почему-то решили, что это ОФИГЕННАЯ ВОЗМОЖНОСТЬ быть тупым ЛРП быдло. Причём на начальные роли заходят самые робастные игроки, которые даже РПшить не хотят и в отделе появляются раз в столетие. 
Ну серьёзно, теперь непонятно кого надо реально обучать, а кого нет. Пропало это чувство "ООО, кадетик!!!".  И в итоге всё скатывается в ЛРП

:cl:
- tweak: Возвращено требование времени для игры на интерн ролях.