### PR TITLE
Add "shortest" ghost raffle and change xeno

### DIFF
--- a/Resources/Prototypes/Corvax/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/Corvax/GhostRoleRaffles/settings.yml
@@ -1,0 +1,6 @@
+- type: ghostRoleRaffleSettings
+  id: shortest
+  settings:
+    initialDuration: 5
+    joinExtendsDurationBy: 2
+    maxDuration: 7

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -101,7 +101,7 @@
     description: ghost-role-information-xeno-description
     rules: ghost-role-information-rules-default-team-antagonist
     raffle:
-      settings: default
+      settings: shortest # Corvax
   - type: GhostTakeoverAvailable
   - type: TypingIndicator
     proto: alien

--- a/Resources/Prototypes/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/GhostRoleRaffles/settings.yml
@@ -13,3 +13,12 @@
     initialDuration: 10
     joinExtendsDurationBy: 2
     maxDuration: 15
+
+# Corvax-start
+- type: ghostRoleRaffleSettings
+  id: shortest
+  settings:
+    initialDuration: 5
+    joinExtendsDurationBy: 2
+    maxDuration: 7
+# Corvax-end

--- a/Resources/Prototypes/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/GhostRoleRaffles/settings.yml
@@ -13,12 +13,3 @@
     initialDuration: 10
     joinExtendsDurationBy: 2
     maxDuration: 15
-
-# Corvax-start
-- type: ghostRoleRaffleSettings
-  id: shortest
-  settings:
-    initialDuration: 5
-    joinExtendsDurationBy: 2
-    maxDuration: 7
-# Corvax-end


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Добавил "shortest" рафл. Это нужно для ксено, чтобы людям не приходилось ждать 30 секунд для игры на презренном Бурильщике. В целом на Ксено не похуй только на Пилигриме, но есть нюанс. Их убивают еще до того, как госты успеют взять роли, а для них как бы оно и создавалось. 

Теперь чтобы взять ксено нужно ждать 5 секунд в лотерее вместо 30-ти. 

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl: Ko4erga
- tweak: Время лотереи для ксено уменьшено с 30 до 5 секунд.
