### PR TITLE
Предотвращение миссклика по суициду.

### DIFF
--- a/Resources/Prototypes/Actions/crit.yml
+++ b/Resources/Prototypes/Actions/crit.yml
@@ -12,6 +12,11 @@
       sprite: Mobs/Ghosts/ghost_human.rsi
       state: icon
     event: !type:CritSuccumbEvent
+    # Corvax MRP-start - Предотвращает суициды по миссклику.
+    useDelay: 3
+  - type: ConfirmableAction
+    popup: suicide-action-popup
+    # Corvax MRP-end
 
 - type: entity
   id: ActionCritFakeDeath


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## Что это?
Это просто **предложение** по тому, как можно было бы реализовать анти миссклик систему для подтверждения самоубийства в крите. **На тот случай, если не найдется другого варианта.**

## Описание PR
Добавляет требование повторного нажатия для подтверждения самоубийства в состоянии крита.
На повторное нажатие навешивается delay на 3 секунды, чего достаточно чтобы ConfirmableAction не откатился (у него откат 5 секунд).

## Почему / Баланс
@lzk228 обещал добавить delay на 10 секунд для кнопки самоубийства чтобы правило отменили, но в итоге пока ничего не сделал. А правило уже отменили.
![image](https://github.com/user-attachments/assets/59c9db09-d249-4440-beeb-441a26320fde)
