### PR TITLE
Заменить турель синдиката на вражескую.

### DIFF
--- a/Resources/Maps/Ruins/corvax_syndi_base.yml
+++ b/Resources/Maps/Ruins/corvax_syndi_base.yml
@@ -10703,7 +10703,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -31.533657,11.152694
       parent: 1
-- proto: WeaponTurretSyndicate
+- proto: WeaponTurretHostile
   entities:
   - uid: 1076
     components:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Заменена турель синдиката на враждебную ко всем турель. Да, немношк не лорно для синди обломка, но не прикольно когда антагутиль способен пройти через все приготовленные для него ловушки и выйти полностью вооруженным. Це не моя придумка, це слова из комментариев.
## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Потому что слишком изи.
## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
WeaponTurretSyndicate заменено на WeaponTurretHostile.
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
![image](https://github.com/user-attachments/assets/08bbff09-d054-448b-b734-c695ea09ad4f)
