### PR TITLE
Fix missing gender variable

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -7,12 +7,14 @@ using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
 using Content.Server.Station.Components;
 using Content.Shared.Database;
+using Content.Shared.Humanoid;
 using Content.Shared.Mind;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
 using JetBrains.Annotations;
+using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
@@ -233,6 +235,10 @@ namespace Content.Server.GameTicking
 
             _mind.TransferTo(newMind, mob);
 
+            Gender gender = Gender.Epicene;
+            if (TryComp<HumanoidAppearanceComponent>(mob, out var appearance))
+                gender = appearance.Gender;
+
             if (lateJoin && !silent)
             {
                 if (jobPrototype.JoinNotifyCrew)
@@ -254,7 +260,8 @@ namespace Content.Server.GameTicking
                             ("character", MetaData(mob).EntityName),
                             ("gender", character.Gender), // Corvax-LastnameGender
                             ("entity", mob),
-                            ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))),
+                            ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName)),
+                            ("gender", gender.ToString().ToLowerInvariant())),
                         Loc.GetString("latejoin-arrival-sender"),
                         playDefaultSound: false);
                 }


### PR DESCRIPTION
## Описание PR
Добавил недостающую переменную гендера в сообщение о прибытии.

Первый раз пишу ПР корваксу, так что не уверен, стоит ли оборачивать изменения в `// Corvax gender fix`. Если нужно, быстренько подправлю.

## Почему / Баланс
Мне надоело видеть `loc: "ru-RU"/"latejoin-arrival-announcement": "Unknown variable: $gender"` каждый раз.

## Технические детали
Из моба, в которого только что вселился игрок, достаётся `HumanoidAppearanceComponent`, который там должен быть всегда, и оттуда получается гендер. Если его там всё же не будет, используется `Gender.Epicene` (они).

## Медиа

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

![image](https://github.com/user-attachments/assets/0d8bb85b-6845-4928-9aad-60488fc678b7)

## Критические изменения
Игроки узнают, кто такие женщины.

**Список изменений**
no cl no fun