### PR TITLE
dragon weight down

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -160,7 +160,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 3,5 # Corvax
+    weight: 3.5 # Corvax
     earliestStart: 40
     reoccurrenceDelay: 20
     minimumPlayers: 20

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -160,7 +160,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 6.5
+    weight: 3,5 # Corvax
     earliestStart: 40
     reoccurrenceDelay: 20
     minimumPlayers: 20


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
уменьшение спавн рейта дракона 
## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Дракон появляется буквально почти каждый раунд, неминуемо неся за собой РДМ... мы же вроде против ДМа? сейчас дракон появляется в 8/10 раундов... из за чего режим выживания, такой, который был 1,5 года назад, нервно курит в сторонке. 


**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
-->
изменение весов в спавн ивенте дракона