### PR TITLE
Цель предателя на диск ядерной активации теперь шансы уменьшены (попытка 2)

### DIFF
--- a/Resources/Prototypes/Corvax/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Corvax/Objectives/objectiveGroups.yml
@@ -1,4 +1,4 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupNukieDisk
   weights:
-    NukeDiskStealObjective: 0.05
+    NukeDiskStealObjective: 1

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -6,7 +6,7 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
-    TraitorObjectiveGroupNukieDisk: 1  #Corvax
+    TraitorObjectiveGroupNukieDisk: 0.05  #Corvax
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Шанс на выпадения задания на получения диска ядерной активации был 1/5 (20%), но теперь 0.05/5 (1%).
Traitor nuke disk objective now 0.05/5 instead of 1/5
<!-- Что вы изменили? -->

## Почему / Баланс
Диск ядерной активации по сложности как Хиджак, а может даже и выше, так как есть пинпойнтеры ведущие на диск ядерной активации, а даже если они были выкрадены, то всё СБ имеет право всю смену держать Красный Код по причине СРП Командования - В случае потери диска ядерной аутентификации, Капитан обязан его вернуть **любыми средствами**.
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

## Технические детали
Опечатка, шансы были выставлены на одну единственную цель в группе, а нужно было выставить на группу в целом.
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- tweak: Цель предателя на диск ядерной активации теперь имеет шанс 1%.
