### PR TITLE
Syndicate footsoldiers now have death acidifier as an autoimplant

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -65,7 +65,7 @@
         task: SimpleHumanoidHostileCompound
     - type: AutoImplant
         implants:
-          - DeathAcidifierImplant
+        - DeathAcidifierImplant
 
 - type: entity
   name: syndicate shuttle pilot

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -63,9 +63,11 @@
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound
+    # Corvax-start
     - type: AutoImplant
       implants:
         - DeathAcidifierImplant # Corvax anti-overloot
+    # Corvax-end
 
 - type: entity
   name: syndicate shuttle pilot

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -65,7 +65,7 @@
         task: SimpleHumanoidHostileCompound
     - type: AutoImplant
       implants:
-        - DeathAcidifierImplant
+        - DeathAcidifierImplant # Corvax anti-overloot
 
 - type: entity
   name: syndicate shuttle pilot

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -91,7 +91,6 @@
         Blunt: 19
   - type: Inventory
     templateId: corpse
-  
 
 - type: entity
   parent: MobHuman

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -63,6 +63,9 @@
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound
+    - type: AutoImplant
+        implants:
+          - DeathAcidifierImplant
 
 - type: entity
   name: syndicate shuttle pilot
@@ -88,6 +91,7 @@
         Blunt: 19
   - type: Inventory
     templateId: corpse
+  
 
 - type: entity
   parent: MobHuman

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -64,7 +64,7 @@
       rootTask:
         task: SimpleHumanoidHostileCompound
     - type: AutoImplant
-        implants:
+      implants:
         - DeathAcidifierImplant
 
 - type: entity


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Добавлен компонент AutoImplant Пехотинцам Синдиката, с имплантом DeathAcidifierImplant.

## Почему / Баланс
Так как мапперы любят добавлять неписей с оружиями на свои обломки, то это провоцирует оверлут, даже если непись не может опустить оружие (его можно получить, гибнув NPC). Данный ПР предотвратит излишнее количество оверлута на обломках мапперов

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: 
- tweak: Пехотинцы синдиката отныне растворяются при смерти

