### PR TITLE
nerf maxcap radius

### DIFF
--- a/Resources/ConfigPresets/Corvax/mrp.toml
+++ b/Resources/ConfigPresets/Corvax/mrp.toml
@@ -14,6 +14,7 @@ enable_during_round = false
 [atmos]
 space_wind = true
 space_wind_max_velocity = 22.0
+max_explosion_range = 9.0
 
 [shuttle]
 emergency_early_launch_allowed = true

--- a/Resources/ConfigPresets/Corvax/mrp.toml
+++ b/Resources/ConfigPresets/Corvax/mrp.toml
@@ -14,7 +14,7 @@ enable_during_round = false
 [atmos]
 space_wind = true
 space_wind_max_velocity = 22.0
-max_explosion_range = 9.0
+max_explosion_range = 10.0
 
 [shuttle]
 emergency_early_launch_allowed = true


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Переоткрыт PR на нерф радиуса подрыва лимиток - https://github.com/space-syndicate/space-station-14/pull/2680
В этот раз радиус установлен по уровню примерно как бомба синдиката.
![image](https://github.com/user-attachments/assets/9f9e7056-2065-46c7-a949-8c1d2faa0443)

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Приводим к виду как на ваниле, но немножко выше, по запросу администрации.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:

- tweak: Радиус взрыва лимиток уменьшен до примерного радиусе взрыва бомбы синдиката 26 -> 10. (Corvax Only)
