### PR TITLE
Удаление женского Displacement Map у ящеров

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -70,12 +70,6 @@
   - type: Wagging
   - type: Inventory
     speciesId: reptilian
-    femaleDisplacements:
-      jumpsuit:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Human/displacement.rsi
-            state: jumpsuit-female
     # Corvax-Digitigrade-Start
     displacements:
       jumpsuit:
@@ -105,12 +99,6 @@
     - HeadSide
   - type: Inventory
     speciesId: reptilian
-    femaleDisplacements:
-      jumpsuit:
-        sizeMaps:
-          32:
-            sprite: Mobs/Species/Human/displacement.rsi
-            state: jumpsuit-female
     # Corvax-Digitigrade-Start
     displacements:
       jumpsuit:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
# !!! Перед тем как мерджить !!!
**Этот ПР на случай если женские дисплейсменты для ящеров не были сделаны по какой-либо причине** 
![изображение](https://github.com/user-attachments/assets/3c2bb4af-fb9c-409d-ab6b-dff6b0266e6d)

## Описание PR
Убраны конфликтующие дисплейсменты для ящеров женского пола, вместо них используются стандартные мужские дисплейсменты (короче всё как было раньше). Новые дисплейсменты не добавлены :/

## Почему / Баланс
fixes #2808

## Технические детали
нету

## Медиа
Я не нашёл картинку с багом, но там короче одежда была с дисплейсментами обычного хумана, но наложена она нашего косолапого ящера. В итоге колени выпирали из под одежды

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl: csqrb
- fix: Унатхи женского пола теперь имеют старое отображение одежды на себе.
