### PR TITLE
Revert "Rebalancing zombie mode chances"

### DIFF
--- a/Resources/Prototypes/Corvax/secret_weights.yml
+++ b/Resources/Prototypes/Corvax/secret_weights.yml
@@ -2,8 +2,8 @@
   id: CorvaxSecretDefault
   weights:
     Nukeops: 0.15
-    Traitor: 0.45
-    Zombie: 0.20
+    Traitor: 0.60
+    Zombie: 0.05
     Extended: 0.05
     Survival: 0.10 
     Revolutionary: 0.05


### PR DESCRIPTION
Возвращает значения весов режимов к стандартным.
По запросу старшей администрации.

P.S. Эксперимент с измененными правилами зомби-режима продолжается, снижаются только шансы на сам режим.
Reverts space-syndicate/space-station-14#2791

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Шансы режимов были ванилизированы.
