### PR TITLE
Change cyrillic sticks tongue out from р to ь in chatsat

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -26,7 +26,6 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "рофл", "chatsan-laughs" },
         { "яхз", "chatsan-shrugs" },
         { ":0", "chatsan-surprised" },
-        { ":р", "chatsan-stick-out-tongue" }, // cyrillic р
         { "кек", "chatsan-laughs" },
         { "T_T", "chatsan-cries" },
         { "Т_Т", "chatsan-cries" }, // cyrillic T

--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -26,7 +26,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "рофл", "chatsan-laughs" },
         { "яхз", "chatsan-shrugs" },
         { ":0", "chatsan-surprised" },
-        { ":Ь", "chatsan-stick-out-tongue" },
+        { ":ь", "chatsan-stick-out-tongue" },
         { "кек", "chatsan-laughs" },
         { "T_T", "chatsan-cries" },
         { "Т_Т", "chatsan-cries" }, // cyrillic T

--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -26,6 +26,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "рофл", "chatsan-laughs" },
         { "яхз", "chatsan-shrugs" },
         { ":0", "chatsan-surprised" },
+        { ":Ь", "chatsan-stick-out-tongue" },
         { "кек", "chatsan-laughs" },
         { "T_T", "chatsan-cries" },
         { "Т_Т", "chatsan-cries" }, // cyrillic T


### PR DESCRIPTION
:р используется для рации по умолчанию, поэтому заменил на :ь