### PR TITLE
Небольшая правка рецепта

### DIFF
--- a/Resources/Prototypes/Corvax/Lathes/misc.yml
+++ b/Resources/Prototypes/Corvax/Lathes/misc.yml
@@ -1,7 +1,4 @@
 - type: latheRecipe
   id: PrinterDocMachineCircuitboard
+  parent: BaseCircuitboardRecipe
   result: PrinterDocMachineCircuitboard
-  completetime: 4
-  materials:
-     Steel: 100
-     Glass: 900


### PR DESCRIPTION
## Описание PR
У платы принтера стоит завышенная цена по стеклу, хоть у **всех** существующих плат (кроме ЛКП) стоимость составляет 500 единиц или же 5 стекла. Зачем делать так не ясно, поэтому этот ПР правит и делает цену стандартизированной любой плате

## Почему / Баланс
Стандартизация рецепта ко всем существующим. Теперь он не будет мазолить глаза Научному Отделу своей ценой, не схожей со всеми остальными платам и больше никогда не придется менять сам рецепт из-за парента, почему - _логично_

## Технические детали
Просто фактически поправлен 1 рецепт, с изменением на стандартный парент `BaseCircuitboardRecipe` у плат

:cl:
- fix: Стандартизирован рецепт платы принтера
