### PR TITLE
Небольшие правки

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Devices/pda.yml
@@ -6,6 +6,11 @@
   components:
     - type: Pda
       id: IAAIDCard
+    - type: Appearance
+      appearanceDataInit:
+        enum.PdaVisuals.PdaType:
+          !type:String
+          pda-lawyer
     - type: PdaBorderColor
       borderColor: "#6f6192"
     - type: Icon
@@ -19,6 +24,11 @@
   components:
     - type: Pda
       id: PilotIDCard
+    - type: Appearance
+      appearanceDataInit:
+        enum.PdaVisuals.PdaType:
+          !type:String
+          pda-seniorofficer
     - type: PdaBorderColor
       borderColor: "#A32D26"
       accentVColor: "#DFDFDF"

--- a/Resources/Prototypes/Corvax/Loadouts/Jobs/Security/security.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/Jobs/Security/security.yml
@@ -1,4 +1,11 @@
+# Shoes
 - type: loadout
   id: JackSecBoots
   equipment:
     shoes: ClothingShoesBootsJackSecFilled
+
+# Outerclothing
+- type: loadout
+  id: ArmorVestSec
+  equipment:
+    outerClothing: ClothingOuterVestArmorSec

--- a/Resources/Prototypes/Corvax/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/role_loadouts.yml
@@ -18,6 +18,6 @@
   - SecurityOuterClothing
   - SecurityBelt
   - SecurityShoes
-  - Survival
+  - SurvivalSecurity
   - Trinkets
   - GroupSpeciesBreathTool

--- a/Resources/Prototypes/Corvax/Roles/Jobs/Command/iaa.yml
+++ b/Resources/Prototypes/Corvax/Roles/Jobs/Command/iaa.yml
@@ -37,6 +37,3 @@
     pocket2: BookSpaceLaw
   inhand:
     - BriefcaseIAAFilled
-  storage:
-    back:
-    - BoxSurvival

--- a/Resources/Prototypes/Corvax/Roles/Jobs/Security/pilot.yml
+++ b/Resources/Prototypes/Corvax/Roles/Jobs/Security/pilot.yml
@@ -33,6 +33,5 @@
     pocket1: WeaponPistolMk58
   storage:
     back:
-    - BoxSurvivalSecurity
     - Flash
     - MagazinePistol

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1055,6 +1055,7 @@
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
   loadouts:
+  - ArmorVestSec # Corvax
   - ArmorVest
   - ArmorVestSlim
   - SecurityOfficerWintercoat
@@ -1110,8 +1111,8 @@
   id: SecurityCadetJumpsuit
   name: loadout-group-security-cadet-jumpsuit
   loadouts:
-  - RedJumpsuit
-  - RedJumpskirt
+  - SecurityJumpsuitGrey # Corvax-Resprite
+  - SecurityJumpskirtGrey # Corvax-Resprite
 
 - type: loadoutGroup
   id: SurvivalSecurity


### PR DESCRIPTION
## Описание PR
Небольшие исправления/добавления лодаутов, снаряжения и исправление отображения КПК Пилота и АВД

## Почему / Баланс
Давным-давно кадеты были серыми, это было достаточно красиво, с тех пор https://github.com/space-syndicate/space-station-14/pull/783 
Но после добавления лодаутов никто не хотел им почему-то вернуть их достояние и они были красные некрасивые. Также возвращает в лодаут бронежилет службы безопасности (стилизованных под них). Этот ПР правит это и немного _мелких_ проблем затрагивающих в частности только сборку Corvax

## Технические детали
Небольшие правки изменения от наличия и отсутствия той или иной части кода

## Медиа
![Content Client_Cawn2EXfCt](https://github.com/user-attachments/assets/75c68673-a85c-47a8-aa6f-a0ea9a0470c8)

**Список изменений**
- Кадетам возвращены серые комбинезоны
- Сотрудникам службы безопасности возвращены бронежилеты службы безопасности в лодаут
- Убраны вторые аварийные наборы у пилота и АВД
- Пилоту исправлен аварийный набор на аварийный набор службы безопасности
- Исправлены отображения КПК пилота и АВД

:cl:
- tweak: Возвращено старое снаряжение СБ в лодауты
- fix: Исправлены КПК и некоторое снаряжение