### PR TITLE
Фикс спрайтов шлюзов

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -21,6 +21,11 @@
       shader: unshaded
       map: ["enum.DoorVisualLayers.BaseUnlit"]
       visible: false
+    # Corvax-Resprite-Airlocks-Start
+    - state: closed_unlit
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    # Corvax-Resprite-Airlocks-End
     - state: welded
       map: ["enum.WeldableLayers.BaseWelded"]
     - state: bolted_unlit
@@ -89,6 +94,12 @@
         enum.ElectrifiedLayers.Sparks:
           True: { visible: True }
           False: { visible: False }
+      # Corvax-Resprite-Airlocks-Start
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+          False: { visible: false }
+      # Corvax-Resprite-Airlocks-End
   - type: WiresVisuals
   - type: ElectrocutionHUDVisuals
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -17,6 +17,11 @@
       shader: unshaded
       map: ["enum.DoorVisualLayers.BaseUnlit"]
       visible: false
+    # Corvax-Resprite-Airlocks-Start
+    - state: closed_unlit
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    # Corvax-Resprite-Airlocks-End
     - state: welded
       map: ["enum.WeldableLayers.BaseWelded"]
     - state: bolted_unlit
@@ -82,6 +87,12 @@
         enum.ElectrifiedLayers.Sparks:
           True: { visible: True }
           False: { visible: False }
+      # Corvax-Resprite-Airlocks-Start
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+          False: { visible: false }
+      # Corvax-Resprite-Airlocks-End
   - type: WiresVisuals
   - type: ElectrocutionHUDVisuals
   - type: ApcPowerReceiver


### PR DESCRIPTION
## Описание PR
Исправление отображения спрайта шлюза Корваксной версии из-за изменений вот тут https://github.com/space-wizards/space-station-14/pull/34646
Не понимаю чем было сложно посмотреть код пару минут, чтобы найти источник, а вернее его отсутствие

## Почему / Баланс
Долой нерабочие спрайты, даешь нормальный визуал!

## Технические детали
Простое добавления отображения PowerDeviceVisualLayers.Powered
Нагромождение в прототипе самое наилучшее решение на данный момент, поскольку с большей долей вероятности **НЕ вызовет проблем**, учитывая редкость редактирования файла базового шлюза соответственно

## Медиа
### Вопросы?
![Content Client_BB9GQkMLqi](https://github.com/user-attachments/assets/e10de7b2-a1e9-46b5-ab03-e1de268a0b62)

**Список изменений**
:cl:
- fix: Исправлено отображение шлюзов
