### PR TITLE
Фикс шлюзов Try2

### DIFF
--- a/Content.Client/Doors/AirlockSystem.cs
+++ b/Content.Client/Doors/AirlockSystem.cs
@@ -97,7 +97,7 @@ public sealed class AirlockSystem : SharedAirlockSystem
                 ||  state == DoorState.Opening
                 ||  state == DoorState.Denying
                 || (state == DoorState.Open && comp.OpenUnlitVisible)
-                || (_appearanceSystem.TryGetData<bool>(uid, DoorVisuals.ClosedLights, out var closedLights, args.Component) && closedLights))
+                || (state == DoorState.Closed && comp.OpenUnlitVisible)) // Corvax-Resprite-Airlocks-Edit
                     && !boltedVisible && !emergencyLightsVisible;
         }
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -21,11 +21,6 @@
       shader: unshaded
       map: ["enum.DoorVisualLayers.BaseUnlit"]
       visible: false
-    # Corvax-Resprite-Airlocks-Start
-    - state: closed_unlit
-      shader: unshaded
-      map: ["enum.PowerDeviceVisualLayers.Powered"]
-    # Corvax-Resprite-Airlocks-End
     - state: welded
       map: ["enum.WeldableLayers.BaseWelded"]
     - state: bolted_unlit
@@ -94,12 +89,6 @@
         enum.ElectrifiedLayers.Sparks:
           True: { visible: True }
           False: { visible: False }
-      # Corvax-Resprite-Airlocks-Start
-      enum.PowerDeviceVisuals.Powered:
-        enum.PowerDeviceVisualLayers.Powered:
-          True: { visible: true }
-          False: { visible: false }
-      # Corvax-Resprite-Airlocks-End
   - type: WiresVisuals
   - type: ElectrocutionHUDVisuals
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -17,11 +17,6 @@
       shader: unshaded
       map: ["enum.DoorVisualLayers.BaseUnlit"]
       visible: false
-    # Corvax-Resprite-Airlocks-Start
-    - state: closed_unlit
-      shader: unshaded
-      map: ["enum.PowerDeviceVisualLayers.Powered"]
-    # Corvax-Resprite-Airlocks-End
     - state: welded
       map: ["enum.WeldableLayers.BaseWelded"]
     - state: bolted_unlit
@@ -87,12 +82,6 @@
         enum.ElectrifiedLayers.Sparks:
           True: { visible: True }
           False: { visible: False }
-      # Corvax-Resprite-Airlocks-Start
-      enum.PowerDeviceVisuals.Powered:
-        enum.PowerDeviceVisualLayers.Powered:
-          True: { visible: true }
-          False: { visible: false }
-      # Corvax-Resprite-Airlocks-End
   - type: WiresVisuals
   - type: ElectrocutionHUDVisuals
   - type: ApcPowerReceiver


### PR DESCRIPTION
## Описание PR
Портировано с https://github.com/Rxup/space-station-14/pull/1073 по просьбе @ksen0morph, в комментариях уточнено за использование в MIT сборках.
Исправление света включенных шлюзов соответственно

## Почему / Баланс
Так надо

## Технические детали
- Remove Zekins fix from https://github.com/space-syndicate/space-station-14/pull/3008
- Add fix fix

**Список изменений**
:cl:
- fix: Исправлено отображение шлюзов x2
