### PR TITLE
Map pool tweaks & semi-pops

### DIFF
--- a/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
@@ -5,7 +5,7 @@
   maxRandomOffset: 0
   randomRotation: false
   minPlayers: 0
-  maxPlayers: 35
+  maxPlayers: 25
   stations:
     Cute:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Corvax/Maps/Pools/corvax.yml
+++ b/Resources/Prototypes/Corvax/Maps/Pools/corvax.yml
@@ -1,24 +1,28 @@
 - type: gameMapPool
   id: CorvaxMapPool
   maps:
-  # Highpop
+  # Highpop 55+
   - CorvaxDelta
   - CorvaxAvrite
   - CorvaxAstra
-  - CorvaxPilgrim
-  - Bagel
+  - CorvaxPilgrim # 40+
   - Box
-  # Midpop
-  - CorvaxCute
+
+  # Semi-Highpop 25–65
+  - Bagel
+  # Midpop 25–55
   - CorvaxPaper
   - CorvaxOutpost
   - CorvaxAwesome
   - CorvaxPearl
   - Amber
   - Marathon
-  # Lowpop
-  - CorvaxSilly
+
+  # Semi-Midpop 0–35
   - CorvaxMaus
+  # Lowpop 0–25
+  - CorvaxCute
+  - CorvaxSilly
   - CorvaxTushkan
   - Omega
   - Packed

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -2,7 +2,10 @@
   id: Bagel
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
-  minPlayers: 55 # Corvax-Mapping
+  # Corvax-start
+  minPlayers: 25
+  maxPlayers: 65
+  # Corvax-end
   stations:
     Bagel:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
### Добавлены подкатегории в маппул:
- Семи-Хайпоп для 25–65 человек
- Семи-Мидпоп для 0–35 человек
### Изменения карт
- Bagel перемещен в semi-highpop.
- Maus перемещен в semi-midpop.
- Cute максимальный онлайн уменьшен с 35 до 25.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Некоторые карты ну прям не влазят в три категории популяции. Устал от попыток впихнуть невпихуемое.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
![image](https://github.com/user-attachments/assets/bf4041ec-32cc-42cc-bec0-51379e0a338d)

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl: Ko4erga
- tweak: Изменены настройки онлайна некоторых карт и добавлены подкатегории в маппул.
