### PR TITLE
Fix paradox clone

### DIFF
--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Stacks;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Whitelist;
+using Content.Shared.Corvax.TTS; // Corvax-TTS
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -80,6 +81,14 @@ public sealed class CloningSystem : EntitySystem
                 CopyComp(original, clone.Value, sourceComp);
             }
         }
+
+        // Corvax-TTS-Start
+        if (TryComp<TTSComponent>(original, out var ttsCopy))
+        {
+            var ttsClone = EnsureComp<TTSComponent>(clone.Value);
+            ttsClone.VoicePrototypeId = ttsCopy.VoicePrototypeId;
+        }
+        // Corvax-TTS-End
 
         var cloningEv = new CloningEvent(settings, clone.Value);
         RaiseLocalEvent(original, ref cloningEv); // used for datafields that cannot be directly copied

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Stacks;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Whitelist;
-using Content.Shared.Corvax.TTS; // Corvax-TTS
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -81,14 +80,6 @@ public sealed class CloningSystem : EntitySystem
                 CopyComp(original, clone.Value, sourceComp);
             }
         }
-
-        // Corvax-TTS-Start
-        if (TryComp<TTSComponent>(original, out var ttsCopy))
-        {
-            var ttsClone = EnsureComp<TTSComponent>(clone.Value);
-            ttsClone.VoicePrototypeId = ttsCopy.VoicePrototypeId;
-        }
-        // Corvax-TTS-End
 
         var cloningEv = new CloningEvent(settings, clone.Value);
         RaiseLocalEvent(original, ref cloningEv); // used for datafields that cannot be directly copied

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -55,6 +55,7 @@
   - SouthernAccent
   - SpanishAccent
   - StutteringAccent
+  - TTS # Corvax-TTS
   blacklist:
     components:
     - AttachedClothing # helmets, which are part of the suit


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Теоретический фикс ТТС у парадоксального клона. Протестировать локально, разумеется, не могу.
Нужен ревью и проверка от настоящего программиста.

UPD: Все оказалось проще.

## Почему / Баланс
Потому что ТТС у клона отличается от ТТС от оригинала.


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
В CloningSystem добавлена проверка наличия компонента TTS у исходного игрока и, если он есть, добавляет такой же компонент клону с тем же ID голоса.

UPD: Все оказалось проще.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- fix: Парадоксальные клоны теперь обладают голосом оригинала.
