### PR TITLE
Вернуть отправку целей

### DIFF
--- a/Content.Server/Corvax/StationGoal/StationGoalPaperSystem.cs
+++ b/Content.Server/Corvax/StationGoal/StationGoalPaperSystem.cs
@@ -1,8 +1,8 @@
 using Content.Server.Fax;
-using Content.Server.GameTicking.Events;
 using Content.Server.Station.Systems;
 using Content.Shared.Corvax.CCCVars;
 using Content.Shared.Fax.Components;
+using Content.Shared.GameTicking;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -24,10 +24,10 @@ namespace Content.Server.Corvax.StationGoal
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<RoundStartingEvent>(OnRoundStarting);
+            SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
         }
 
-        private void OnRoundStarting(RoundStartingEvent ev)
+        private void OnRoundStarted(RoundStartedEvent ev)
         {
             if (!_cfg.GetCVar(CCCVars.StationGoal))
                 return;


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Каникулы закончились. Цели снова отправляются на станции в начале смены.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Багфикс.
