### PR TITLE
remove atmos rip tiles from echo

### DIFF
--- a/Resources/ConfigPresets/Corvax/echo.toml
+++ b/Resources/ConfigPresets/Corvax/echo.toml
@@ -21,8 +21,3 @@ time = 10.0
 [hub]
 advertise = true
 tags = "lang:ru,rp:med,region:eu_e,tts"
-
-[atmos]
-monstermos_equalization = true
-monstermos_depressurization = true
-monstermos_rip_tiles = true

--- a/Resources/ConfigPresets/Corvax/echo.toml
+++ b/Resources/ConfigPresets/Corvax/echo.toml
@@ -21,3 +21,7 @@ time = 10.0
 [hub]
 advertise = true
 tags = "lang:ru,rp:med,region:eu_e,tts"
+
+[atmos]
+monstermos_equalization = true
+monstermos_depressurization = true


### PR DESCRIPTION
это сильно надоедает, а учитывая, что мапперы корвакса любят налепить миллион декалей, после переустановки плитки, они пропадают и всё выглядит по уродски
![Screenshot_20250411_214211](https://github.com/user-attachments/assets/43f2b4c2-8742-47f9-90e7-206b746b998d)
