### PR TITLE
remove powerloot from brigmedic

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -134,8 +134,6 @@
       - id: PowerCellHigh 
         amount: 2 
       - id: MedkitAdvancedFilled 
-      - id: BoxMiniSyringe 
-      - id: LauncherSyringe 
         # Corvax-Brigmedic-End
 
 - type: entity


### PR DESCRIPTION
убрал мини шприцы и шприцемёт так как они пока что не должны быть использованы в игре вообще