### PR TITLE
Remove overloot from brigmed

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -131,11 +131,7 @@
       - id: ClothingMaskBreathMedicalSecurity 
       - id: BoxBodyBag 
       - id: Defibrillator 
-      - id: PowerCellHigh 
-        amount: 2 
       - id: MedkitAdvancedFilled 
-      - id: BoxMiniSyringe 
-      - id: LauncherSyringe 
         # Corvax-Brigmedic-End
 
 - type: entity


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Убрал 2 батарейки высокого напряжения у бригмеда, потому что их убрали из фонариков СБ и шприцемёт, потому что это вещь, которая должна спавниться админами
## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Потому что это оверлут
## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->
**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- remove: удалены батарейки высокой ёмкости у бригмедика
- remove: удалён шприцемёт и мини-шприцы у бригмедика