### PR TITLE
Brigmedic-Spacesuit changes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -276,12 +276,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.7
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.9
   - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic


### PR DESCRIPTION
Код по предложке. Изменены статы скафандра.
Замедление 35% -> 10%
Ударный 20% -> 5%
Режущий 20% -> 5%
Колющий 30% -> 10%
Шлем не трогал
## Описание PR
Изменены статы скафандра бригмедика
## Почему / Баланс
Урезаны характеристики защиты в угоду скорости перемещения.
## Медиа
![image](https://github.com/user-attachments/assets/7016b2ca-7952-4374-94cc-ff7d3de01c4a)

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- tweak: Замедление 35% -> 10%
              Ударный 20% -> 5%
              Режущий 20% -> 5%
              Колющий 30% -> 10%
-->
