### PR TITLE
make galoshes normal

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -116,9 +116,9 @@
   - type: NoSlip
   - type: SlowedOverSlippery
     slowdownModifier: 0.7
-  - type: SpeedModifierContactCapClothing # Corvax-MRP
-    maxContactSprintSlowdown: 0.9
-    maxContactWalkSlowdown: 0.9
+  - type: SpeedModifierContactCapClothing
+    maxContactSprintSlowdown: 0.7
+    maxContactWalkSlowdown: 0.7
 
 - type: entity
   parent: [ClothingShoesBaseButcherable, BaseMajorContraband]


### PR DESCRIPTION
вернул галошам дефолтные значения, не понимаю причём тут метка mrp от морти и как быстрая ходьба в галошах по лужах увеличивает рп

для тех кто в танке, галоши уже давно замедляют только если ходить по лужах