### PR TITLE
Make lawbounded not pacified at round end

### DIFF
--- a/Content.Server/Corvax/PeacefulRoundEnd/PeacefulRoundEndSystem.cs
+++ b/Content.Server/Corvax/PeacefulRoundEnd/PeacefulRoundEndSystem.cs
@@ -29,7 +29,8 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
             if (!session.AttachedEntity.HasValue) continue;
 
             var entityId = session.AttachedEntity.Value;
-            if (HasComp<MindShieldComponent>(entityId))
+            if (HasComp<MindShieldComponent>(entityId)
+                || HasComp<SiliconLawBoundComponent>(entityId))
             {
                 continue;
             }

--- a/Content.Server/Corvax/PeacefulRoundEnd/PeacefulRoundEndSystem.cs
+++ b/Content.Server/Corvax/PeacefulRoundEnd/PeacefulRoundEndSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Corvax.CCCVars;
 using Content.Shared.Mindshield.Components;
+using Content.Shared.Silicons.Laws.Components;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 


### PR DESCRIPTION
нет смысла давать пацифизм боргам (и прочим у кого есть законы) в конце раунда, так как их законы = их правила и по сути если у них и есть закон на харм, то зачем их ограничивать?

:cl:
- tweak: Борги и прочие сущности с кремниевыми законами не будут получать пацифизм в конце раунда.