### PR TITLE
Fix sponsor-only markings filter

### DIFF
--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -218,9 +218,9 @@ public sealed partial class MarkingSet
             {
                 if (prototypeManager.TryIndex<MarkingPrototype>(marking.MarkingId, out var proto) && !proto.SponsorOnly)
                 {
-                    return;
+                    continue;
                 }
-                
+
                 var allowedToHave = sponsorMarkings.Contains(marking.MarkingId);
                 if (!allowedToHave)
                 {


### PR DESCRIPTION
rookie mistake