### PR TITLE
Мини фикс КПК пилота

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Devices/pda.yml
@@ -17,7 +17,7 @@
       state: pda-lawyer
 
 - type: entity
-  parent: BasePDA
+  parent: BaseSecurityPDA
   id: PilotPDA
   name: pilot PDA
   description: Нas protection from cosmic radiation.


### PR DESCRIPTION
## Описание PR
Небольшая техническая правка для КПК пилота СБ, ничего более

## Почему / Баланс
Пилот является сотрудником службы безопасности на уровне с офицерами, но все ещё не имел списка разыскиваемых в своем КПК
Данное прекрасное изменение правит данную оплошность и устраняет проблемы с изменениями в будущем

## Технические детали
Да

**Список изменений**
:cl:
- fix: Теперь КПК пилота как КПК СБ!