### PR TITLE
No Ipc for ERT

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -44,7 +44,7 @@
   id: DeathSquad
   parent: EventHumanoidCentcomm
   randomizeName: false
-  speciesBlacklist: ['Diona'] # Corvax-MRP
+  speciesBlacklist: ['Diona', 'Ipc'] # Corvax-MRP
   components:
     - type: GhostRole
       name: ghost-role-information-Death-Squad-name
@@ -86,6 +86,9 @@
   id: ERTLeader
   parent: EventHumanoidCentcomm
   randomizeName: false
+  speciesBlacklist: # Corvax-MRP
+    - Diona
+    - Ipc
   components:
     - type: GhostRole
       name: ghost-role-information-ert-leader-name
@@ -376,6 +379,7 @@
   id: ERTSecurity
   speciesBlacklist: # Corvax-MRP
     - Diona
+    - Ipc
   parent: ERTLeader
   components:
     - type: GhostRole
@@ -526,6 +530,7 @@
 - type: randomHumanoidSettings
   speciesBlacklist: # Corvax-MRP
     - Diona
+    - Ipc
   id: CBURNAgent
   parent: EventHumanoidCentcomm
   components:


### PR DESCRIPTION
## Описание PR
Элитные бойцы ЦК теперь без КПБ.

## Почему / Баланс
КПБ как раса очень слабая, в бою падёт от 2 пуль, медик мало чем поможет, падает от любого ЭМИ. Данной расе не место в отрядах бойцов.

## Технические детали
Добавлены speciesBlacklist для некоторых настроек обр и рхбзз. В некоторые speciesBlacklist добавлены сами кпб

## Медиа
-

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
