### PR TITLE
Say NO WIZARD!

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -39,7 +39,7 @@
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn
-    - id: WizardSpawn
+    #- id: WizardSpawn
 
 - type: entity
   id: BaseStationEvent
@@ -293,9 +293,9 @@
   - type: StationEvent
     weight: 1 # rare
     duration: 1
-    earliestStart: 30
+    earliestStart: 60
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 45
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -22,8 +22,8 @@
     rules:
     - id: Thief
       prob: 0.5
-    - id: SubWizard
-      prob: 0.05
+    #- id: SubWizard
+    #  prob: 0.05
 
 - type: entity
   parent: BaseGameRule
@@ -282,7 +282,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 45
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -6,4 +6,4 @@
     Zombie: 0.05
     Survival: 0.10
     Revolutionary: 0.05
-    Wizard: 0.05 # Why not, should probably be lower
+#    Wizard: 0.05 # Why not, should probably be lower


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Удалена возможность выпадения самостоятельно мага + на будущее увеличен минимальный его порог.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Потому что этот ебланоид щас такую хуйню может творить, так что лучше пусть будет появляться только под наблюдением администрации.

## Ссылка на ветку
<!-- Необязательный пункт. Удалите раздел целиком, если он пуст.
Ссылка на ветку обсуждения ПРа в Discord.
Следите, чтобы информация в первом сообщении была актуальной. -->
Закрытые чаты :cat_xdd:

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
По факту - просто комиты/изменение параметров

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- remove: Удалена возможность появления мага в раунде.
-->
:cl:
- remove: Удалена возможность появления мага в раунде.