### PR TITLE
Lore species ages

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -65,7 +65,7 @@
                                 <BoxContainer HorizontalExpand="True">
                                     <Label Text="{Loc 'humanoid-profile-editor-age-label'}" />
                                     <Control HorizontalExpand="True"/>
-                                    <LineEdit Name="AgeEdit" MinSize="40 0" HorizontalAlignment="Right" />
+                                    <LineEdit Name="AgeEdit" MinSize="60 0" HorizontalAlignment="Right" /> <!-- Corvax-SpeciesAgeLore -->
                                 </BoxContainer>
                                 <!-- Sex -->
                                 <BoxContainer HorizontalExpand="True">

--- a/Resources/Prototypes/Corvax/Species/ipc.yml
+++ b/Resources/Prototypes/Corvax/Species/ipc.yml
@@ -13,6 +13,7 @@
   femaleFirstNames: NamesIpcFirstFemale
   maleLastNames: NamesIpcLast # Corvax-LastnameGender
   femaleLastNames: NamesIpcLast # Corvax-LastnameGender
+  minAge: 0
 
 - type: speciesBaseSprites
   id: MobIpcSprites

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -13,9 +13,11 @@
   maleLastNames: NamesDionaLast # Corvax-LastnameGender
   femaleLastNames: NamesDionaLast # Corvax-LastnameGender
   naming: TheFirstofLast
-  youngAge: 3000 # Corvax-SpeciesAgeLore
-  oldAge: 6000 # Corvax-SpeciesAgeLore
-  maxAge: 12000  # Corvax-SpeciesAgeLore
+  # Corvax-SpeciesAgeLore-Start
+  youngAge: 3000
+  oldAge: 6000
+  maxAge: 12000
+  # Corvax-SpeciesAgeLore-End
 
 - type: speciesBaseSprites
   id: MobDionaSprites

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -13,6 +13,9 @@
   maleLastNames: NamesDionaLast # Corvax-LastnameGender
   femaleLastNames: NamesDionaLast # Corvax-LastnameGender
   naming: TheFirstofLast
+  youngAge: 3000 # Corvax-SpeciesAgeLore
+  oldAge: 6000 # Corvax-SpeciesAgeLore
+  maxAge: 12000  # Corvax-SpeciesAgeLore
 
 - type: speciesBaseSprites
   id: MobDionaSprites

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,3 +7,6 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
+  youngAge: 60 # Corvax-SpeciesAgeLore
+  oldAge: 300 # Corvax-SpeciesAgeLore
+  maxAge: 600 # Corvax-SpeciesAgeLore

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,6 +7,8 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
-  youngAge: 60 # Corvax-SpeciesAgeLore
-  oldAge: 300 # Corvax-SpeciesAgeLore
-  maxAge: 600 # Corvax-SpeciesAgeLore
+  # Corvax-SpeciesAgeLore-Start
+  youngAge: 60
+  oldAge: 300
+  maxAge: 600
+  # Corvax-SpeciesAgeLore-End


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Изменил дионе, дворфам и КПБ промежуток доступных значений возраста. Указаны доступные для игры значения (персонажей за пределами этих значений встретить не возможно).

Также увеличил окошко интерфейса в кастомизации, чтобы возраст туда влезал

КПБ
0-30 молодой
30-60 средний возраст
60-120 старый

Дворф
18-60 молодой
60-300 средний возраст
300-600 старый

Диона
18-3000 молодой
3000-6000 средний возраст
6000-12000 старый

## Почему / Баланс
С самого назначения на куратора лора ксеноморф сказал, что лор будут внедрять в игру (по аналогии с контейнерами корп)

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Дионам, дворфам и КПБ были изменены доступные значения для возраста
