### PR TITLE
Блять, я уберал цель у вора.

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -80,8 +80,7 @@
     ClothingHeadsetAltMedicalStealObjective: 1
     FireAxeStealObjective: 1                            #eng
     AmePartFlatpackStealObjective: 1
-    ExpeditionsCircuitboardStealObjective: 1            #sup
-    CargoShuttleCircuitboardStealObjective: 1
+    CargoShuttleCircuitboardStealObjective: 1           #sup
     ClothingEyesHudBeerStealObjective: 1                #srv
     BibleStealObjective: 1
     ClothingNeckGoldmedalStealObjective: 1              #other

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -229,13 +229,6 @@
     state: ame-part
 
 - type: stealTargetGroup
-  id: SalvageExpeditionsComputerCircuitboard
-  name: steal-target-groups-salvage-expeditions-computer-circuitboard
-  sprite:
-    sprite: Objects/Misc/module.rsi
-    state: cpu_supply
-
-- type: stealTargetGroup
   id: CargoShuttleConsoleCircuitboard
   name: steal-target-groups-cargo-shuttle-console-circuitboard
   sprite:

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -250,17 +250,6 @@
 
 - type: entity                                      #Cargo subgroup
   parent: BaseThiefStealObjective
-  id: ExpeditionsCircuitboardStealObjective
-  components:
-  - type: NotJobRequirement
-    job: SalvageSpecialist
-  - type: StealCondition
-    stealGroup: SalvageExpeditionsComputerCircuitboard
-  - type: Objective
-    difficulty: 0.7
-
-- type: entity
-  parent: BaseThiefStealObjective
   id: CargoShuttleCircuitboardStealObjective
   components:
   - type: NotJobRequirement


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Цель у вора на кражу платы Экспедиции была УДАЛЕНА

## Почему / Баланс
Потому что потому. Саму консоль экспедиций давным давно убрали, а плату сделали крафтовой, то есть возобновляемой. Цель на кражу данной платы становится либо - крайне сложной ведь рнд могут тупо не изучить. Либо - до пиздеца простой и незначительной, ведь вору вообще никак не надо лезть у утилям - можно тупо скрафтить у рнд, и самим утилям это жизнь не усложняет, так плата возобновляемая. Пропадает этот прикол целей на кражи плат - обычно все платы что надо красть являются не возобновляемыми и их пропажа мешает работе отдела, а также зачастую находятся в глубине самого отдела. 

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
- remove: Цель вора на кражу платы экспедиций была УДАЛЕНА
