### PR TITLE
[Maps] Mappool tweaks

### DIFF
--- a/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
@@ -5,7 +5,7 @@
   maxRandomOffset: 0
   randomRotation: false
   minPlayers: 0
-  maxPlayers: 35
+  maxPlayers: 25
   stations:
     Maus:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Corvax/Maps/Pools/corvax.yml
+++ b/Resources/Prototypes/Corvax/Maps/Pools/corvax.yml
@@ -10,8 +10,6 @@
   - CorvaxGlacier # 40+
   - Box
 
-  # Semi-Highpop 25–65
-  - Bagel
   # Midpop 25–55
   - CorvaxPaper
   - CorvaxOutpost
@@ -19,10 +17,10 @@
   - CorvaxPearl
   - Amber
   - Marathon
-
-  # Semi-Midpop 0–35
-  - CorvaxMaus
+  - Bagel
+  
   # Lowpop 0–25
+  - CorvaxMaus  
   - CorvaxSilly
   - CorvaxTushkan
   - Packed

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/bagel.yml
   # Corvax-start
   minPlayers: 25
-  maxPlayers: 65
+  maxPlayers: 55
   # Corvax-end
   stations:
     Bagel:


### PR DESCRIPTION
* Убраны категории Семи-хайпоп и семи-мидпоп. 
* Максимальный онлайн Мауса снижен до 25
* Максимальный онлайн Багеля снижен до 55