### PR TITLE
increase time between events overall and fix comment typos

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -48,8 +48,8 @@
   components:
   - type: GameRule
     delay:
-      min:  20 # Corax-MRP # 10
-      max:  30 # Corax-MRP # 20
+      min:  20 # Corvax-MRP # 10
+      max:  30 # Corvax-MRP # 20
 
 - type: entity
   id: BaseStationEventShortDelay
@@ -58,8 +58,8 @@
   components:
   - type: GameRule
     delay:
-      min:  20 # Corax-MRP # 10
-      max:  30 # Corax-MRP # 20
+      min:  20 # Corvax-MRP # 10
+      max:  30 # Corvax-MRP # 20
 
 - type: entity
   id: BaseStationEventLongDelay
@@ -68,8 +68,8 @@
   components:
   - type: GameRule
     delay:
-      min:  50 # Corax-MRP # 40
-      max:  70 # Corax-MRP # 60
+      min:  50 # Corvax-MRP # 40
+      max:  70 # Corvax-MRP # 60
 
 - type: entity
   id: AnomalySpawn
@@ -165,8 +165,8 @@
   components:
   - type: StationEvent
     weight: 6.5
-    earliestStart: 50 # Corax-MRP # 40
-    reoccurrenceDelay: 30 # Corax-MRP # 20
+    earliestStart: 50 # Corvax-MRP # 40
+    reoccurrenceDelay: 30 # Corvax-MRP # 20
     minimumPlayers: 20
     duration: null
   - type: SpaceSpawnRule
@@ -282,7 +282,7 @@
     weight: 7.5
     duration: 1
     earliestStart: 45
-    minimumPlayers: 30 # Corax-MRP # 20
+    minimumPlayers: 30 # Corvax-MRP # 20
   - type: RandomSpawnRule
     prototype: MobRevenant
 
@@ -293,7 +293,7 @@
   - type: StationEvent
     weight: 1 # rare
     duration: 1
-    earliestStart: 40 # Corax-MRP # 30
+    earliestStart: 40 # Corvax-MRP # 30
     reoccurrenceDelay: 60
     minimumPlayers: 10
   - type: AntagSelection
@@ -434,7 +434,7 @@
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    earliestStart: 30 # Corax-MRP # 20
+    earliestStart: 30 # Corvax-MRP # 20
     minimumPlayers: 15
     weight: 5
     duration: 60
@@ -455,7 +455,7 @@
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    earliestStart: 30 # Corax-MRP # 20
+    earliestStart: 30 # Corvax-MRP # 20
     minimumPlayers: 15
     weight: 5
     duration: 60
@@ -476,7 +476,7 @@
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    earliestStart: 30 # Corax-MRP # 20
+    earliestStart: 30 # Corvax-MRP # 20
     minimumPlayers: 15
     weight: 5
     duration: 60
@@ -493,7 +493,7 @@
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    earliestStart: 30 # Corax-MRP # 20
+    earliestStart: 30 # Corvax-MRP # 20
     minimumPlayers: 20
     weight: 1.5
     duration: 60
@@ -545,7 +545,7 @@
   id: LoneOpsSpawn
   components:
   - type: StationEvent
-    earliestStart: 40 # Corax-MRP # 30
+    earliestStart: 40 # Corvax-MRP # 30
     weight: 5.5
     minimumPlayers: 20
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
@@ -581,7 +581,7 @@
   id: SleeperAgents
   components:
   - type: StationEvent
-    earliestStart: 40 # Corax-MRP #
+    earliestStart: 40 # Corvax-MRP #
     weight: 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -48,7 +48,7 @@
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    earliestStart: 20 # Corax-MRP # 15
+    earliestStart: 20 # Corvax-MRP # 15
     weight: 6
     duration: 50
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -400,7 +400,12 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
-
+    # Corvax-MRP-start
+    minMaxEventTiming:
+      min: 6
+      max: 20
+    # Corvax-MRP-end
+  
 - type: entity
   id: RampingStationEventScheduler
   parent: BaseGameRule
@@ -408,11 +413,6 @@
   - type: RampingStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
-  # Corvax-MRP-start
-    minMaxEventTiming:
-      min: 6
-      max: 20
-  # Corvax-MRP-end
     
 - type: entity
   id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -413,7 +413,7 @@
   - type: RampingStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
-    
+
 - type: entity
   id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,
   parent: BaseGameRule                  # we can remerge this with the other schedulers, but it will silently fail due to that limitation without a separate scheduler to balance atm.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -408,10 +408,11 @@
   - type: RampingStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
-    # Corvax-MRP-start
+  # Corvax-MRP-start
+  - type: MinMaxEventTiming
     min: 6
     max: 20
-    # Corvax-MRP-end
+  # Corvax-MRP-end
     
 - type: entity
   id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -409,9 +409,9 @@
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
   # Corvax-MRP-start
-  - type: MinMaxEventTiming
-    min: 6
-    max: 20
+    minMaxEventTiming:
+      min: 6
+      max: 20
   # Corvax-MRP-end
     
 - type: entity

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -408,7 +408,11 @@
   - type: RampingStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
-
+    # Corvax-MRP-start
+    min: 6
+    max: 20
+    # Corvax-MRP-end
+    
 - type: entity
   id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,
   parent: BaseGameRule                  # we can remerge this with the other schedulers, but it will silently fail due to that limitation without a separate scheduler to balance atm.


### PR DESCRIPTION
надо было всего лишь в шедулере ивентов поменять минимальное и максимальное количество между ивентами, а не менять время в отдельных ивентах

изменил время от 3-10 минут до 6-20 (мин и макс)

остальные изменения времени отдельных ивентов можно откатить по желанию

плюсом фиксанул комменты старых коментов