### PR TITLE
reduce auto evac from 150 to 90 seconds

### DIFF
--- a/Resources/ConfigPresets/Corvax/mrp.toml
+++ b/Resources/ConfigPresets/Corvax/mrp.toml
@@ -19,7 +19,6 @@ max_explosion_range = 10.0
 [shuttle]
 emergency_early_launch_allowed = true
 arrivals_map = "/Maps/Corvax/Misc/corvax_terminal.yml"
-auto_call_time = 150
 
 [vote]
 restart_required_ratio = 0.85


### PR DESCRIPTION
уменьшил время авто эвака с 2 часов 30 минут до 1 часа 30 минут, т.к. мало смен даже доживают до такого времени, а авто эвак скорее нужен намного раньше из-за многих угроз и прочее
если кэп не вызывает эвак в угрозе то это вызовет вместо него