### PR TITLE
Изменение лодаута инструктора СБ

### DIFF
--- a/Resources/Prototypes/Corvax/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/loadout_groups.yml
@@ -212,6 +212,7 @@
   id: SeniorOfficerOuterClothing
   name: loadout-group-senior-officer-outerclothing
   loadouts:
+  - ArmorVestSec # Corvax
   - ArmorVest
   - ArmorVestSlim
   - SecurityOfficerWintercoat
@@ -220,6 +221,7 @@
   id: SeniorOfficerShoes
   name: loadout-group-senior-officer-shoes
   loadouts:
+  - JackSecBoots # Corvax
   - JackBoots
   - SecurityWinterBoots
 


### PR DESCRIPTION
## **Описание PR**  
Добавлены недостающие элементы экипировки (броник `ArmorVestSec` и ботинки `JackSecBoots`) в лодауты инструктора СБ для соответствия корвакс-респрайту.  

## **Почему / Баланс**  
- Исправляет упущение: я забыл добавить эти предметы ранее.  
- Сохраняет эстетику корвакс-респрайта и улучшает визуальную согласованность.  
- Не влияет на баланс, так как это косметические/технические правки.  

## **Технические детали**  
- В группу `SeniorOfficerOuterClothing` добавлен `ArmorVestSec`.  
- В группу `SeniorOfficerShoes` добавлен `JackSecBoots`.  

## **Changelog**  
:cl:
- add: В лодаут инструктора добавлены броник `ArmorVestSec` и ботинки `JackSecBoots` (корвакс-респрайт).  