### PR TITLE
[Maps] Pen Centcom Fix

### DIFF
--- a/Resources/Maps/Corvax/corvax_centcomm.yml
+++ b/Resources/Maps/Corvax/corvax_centcomm.yml
@@ -60858,7 +60858,7 @@ entities:
     - type: Transform
       pos: 92.452065,77.90815
       parent: 1
-- proto: PenCap
+- proto: PenCentcom
   entities:
   - uid: 7373
     components:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
По неизвестной причине все ручки центком на сцк мигрировали в капитанские ручки. Заменены обратно на ручки центком.