### PR TITLE
HealthOverlay action

### DIFF
--- a/Content.Server/Corvax/Administration/Systems/AdminHealthOverlaySystem.cs
+++ b/Content.Server/Corvax/Administration/Systems/AdminHealthOverlaySystem.cs
@@ -1,0 +1,34 @@
+﻿using Content.Shared.Administration;
+using Content.Shared.Ghost;
+using Content.Shared.Overlays;
+
+namespace Content.Server.Corvax.Administration.Systems;
+
+public sealed class AdminHealthOverlaySystem : EntitySystem
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    private readonly Component[] _overlays =
+    [
+        new ShowHealthBarsComponent(), new ShowHealthIconsComponent(),
+        new ShowJobIconsComponent(), new ShowMindShieldIconsComponent(),
+        new ShowCriminalRecordIconsComponent(), new ShowSyndicateIconsComponent()
+    ];
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GhostComponent, ActionToggleHealthOverlayEvent>(OnHealthOverlayToggled);
+    }
+
+    private void OnHealthOverlayToggled(Entity<GhostComponent> ent, ref ActionToggleHealthOverlayEvent args)
+    {
+        // EnsureComponent hasn't templateless signature and template signature can't be called with type reference
+        if (Array.TrueForAll(_overlays, overlay => !_entityManager.HasComponent(ent.Owner, overlay.GetType())))
+        {
+            Array.ForEach(_overlays, overlay => _entityManager.AddComponent(ent.Owner, overlay));
+            return;
+        }
+
+        Array.ForEach(_overlays,  overlay => _entityManager.RemoveComponent(ent.Owner, overlay));
+    }
+}

--- a/Content.Server/Corvax/Administration/Systems/AdminHealthOverlaySystem.cs
+++ b/Content.Server/Corvax/Administration/Systems/AdminHealthOverlaySystem.cs
@@ -12,7 +12,7 @@ public sealed class AdminHealthOverlaySystem : EntitySystem
     [
         new ShowHealthBarsComponent(), new ShowHealthIconsComponent(),
         new ShowJobIconsComponent(), new ShowMindShieldIconsComponent(),
-        new ShowCriminalRecordIconsComponent(), new ShowSyndicateIconsComponent()
+        new ShowCriminalRecordIconsComponent()
     ];
 
     public override void Initialize()

--- a/Content.Shared/Administration/SharedAdministrationSystem.cs
+++ b/Content.Shared/Administration/SharedAdministrationSystem.cs
@@ -1,0 +1,5 @@
+﻿using Content.Shared.Actions;
+
+namespace Content.Shared.Administration;
+
+public sealed partial class ActionToggleHealthOverlayEvent : InstantActionEvent;

--- a/Resources/Locale/en-US/corvax/administration/actions.ftl
+++ b/Resources/Locale/en-US/corvax/administration/actions.ftl
@@ -1,0 +1,2 @@
+﻿action-toggle-health-overlay-name = Toggle health overlay
+action-toggle-health-overlay-desc = Enables or disables health overlay (like omnihud).

--- a/Resources/Locale/ru-RU/corvax/administration/actions.ftl
+++ b/Resources/Locale/ru-RU/corvax/administration/actions.ftl
@@ -1,0 +1,2 @@
+﻿action-toggle-health-overlay-name = Перключить оверлей
+action-toggle-health-overlay-desc = Включить или выключить оверлей (почти как омни визор).

--- a/Resources/Prototypes/Corvax/Administration/actions.yml
+++ b/Resources/Prototypes/Corvax/Administration/actions.yml
@@ -1,0 +1,12 @@
+﻿- type: entity
+  parent: BaseAction
+  id: ActionToggleHealthOverlay
+  name: action-toggle-health-overlay-name
+  description: action-toggle-health-overlay-desc
+  components:
+  - type: Action
+    icon:
+      sprite: Clothing/Eyes/Hud/omni.rsi
+      state: icon
+  - type: InstantAction
+    event: !type:ActionToggleHealthOverlayEvent

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -113,6 +113,11 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 30
   # Corvax-End
+  # Corvax-HealthOverlay-action-start
+  - type: ActionGrant
+    actions:
+    - ActionToggleHealthOverlay
+  # Corvax-HealthOverlay-action-end
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -32,13 +32,3 @@
       uiWindowPos: 0,1
       strippingWindowPos: 1,1
       displayName: Mask
-
-    # Corvax aghost-MLG start
-    - name: eyes
-      slotTexture: glasses
-      slotFlags: EYES
-      stripTime: 3
-      uiWindowPos: 0,3
-      strippingWindowPos: 0,0
-      displayName: Eyes
-    # Corvax aghost-MLG end


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Сделал action вместо слота под очки, ревертнул #3384.

## Почему / Баланс
Так удобнее и @DIMMoon1 попросил.

## Технические детали
Кода мало, так что иди и читай.

## Медиа
<img width="368" height="140" alt="image" src="https://github.com/user-attachments/assets/d44f3a8f-53be-4e4e-8fa0-07ef86beca18" />


## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Список изменений
:cl:
- add: Админ призраку добавлен переключатель оверлея омни визора!
