### PR TITLE
Фикс настройки перса

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -419,6 +419,8 @@ namespace Content.Client.Lobby.UI
 
             RefreshTraits();
 
+            TabContainer.SetTabTitle(3, Loc.GetString("humanoid-profile-editor-traits-tab")); // Corvax-TTS-Edit
+
             #region Markings
 
             TabContainer.SetTabTitle(4, Loc.GetString("humanoid-profile-editor-markings-tab"));
@@ -551,7 +553,7 @@ namespace Content.Client.Lobby.UI
             TraitsList.RemoveAllChildren();
 
             var traits = _prototypeManager.EnumeratePrototypes<TraitPrototype>().OrderBy(t => Loc.GetString(t.Name)).ToList();
-            TabContainer.SetTabTitle(3, Loc.GetString("humanoid-profile-editor-traits-tab"));
+            // TabContainer.SetTabTitle(3, Loc.GetString("humanoid-profile-editor-traits-tab")); // Corvax-TTS-Edit
 
             if (traits.Count < 1)
             {


### PR DESCRIPTION
## Описание PR
Данный ПР исправляет корявый таб в настройках персонажа

## Почему / Баланс
**Теперь красиво**

_P.S. Пометка тегом TTS потому что перебор всего таба в новый порядок именно из-за TTS-а_

## Медиа
Было:
<img width="942" height="529" alt="image" src="https://github.com/user-attachments/assets/ba7cec87-7012-4087-918e-3a70a3b09600" />

Стало:
<img width="777" height="48" alt="image" src="https://github.com/user-attachments/assets/7d72b029-0b57-4337-a1ff-a1829287f0fb" />

## Критические изменения
Коммит - Переехал

**Список изменений**
:cl:
- fix: Отображение таба настроек перса
