### PR TITLE
Удаление француского акцента из меню выбора

### DIFF
--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Shared.Speech;
-using Robust.Shared.Random;
+using Robust.Shared.Random; // Russian-Locale
 
 namespace Content.Server.Speech.EntitySystems;
 

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -14,7 +14,6 @@ public sealed class FrenchAccentSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!; // Russian-Locale
 
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexStartH = new(@"(?<!\w)h", RegexOptions.IgnoreCase);
     //Russian-Locale-Start
     private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
     private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
@@ -35,9 +34,6 @@ public sealed class FrenchAccentSystem : EntitySystem
         var msg = message;
 
         msg = _replacement.ApplyReplacements(msg, "french");
-
-        // replaces h with ' at the start of words.
-        msg = RegexStartH.Replace(msg, "'");
 
         // spaces out ! ? : and ;.
         msg = RegexSpacePunctuation.Replace(msg, " $&");
@@ -125,6 +121,7 @@ public sealed class FrenchAccentSystem : EntitySystem
         // Russian-Locale-End
 
         return msg;
+
     }
 
     private void OnAccentGet(EntityUid uid, FrenchAccentComponent component, AccentGetEvent args)

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Shared.Speech;
+using Robust.Shared.Random;
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -10,9 +11,15 @@ namespace Content.Server.Speech.EntitySystems;
 public sealed class FrenchAccentSystem : EntitySystem
 {
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+    // Russian-Locale-Start
+    [Dependency] private readonly IRobustRandom _random = default!;
+    // Russian-Locale-End
 
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexStartH = new(@"(?<!\w)h", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexE = new("e", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexZ = new("з", RegexOptions.IgnoreCase);
     private static readonly Regex RegexSpacePunctuation = new(@"(?<=\w\w)[!?;:](?!\w)", RegexOptions.IgnoreCase);
 
     public override void Initialize()
@@ -27,9 +34,6 @@ public sealed class FrenchAccentSystem : EntitySystem
         var msg = message;
 
         msg = _replacement.ApplyReplacements(msg, "french");
-
-        // replaces h with ' at the start of words.
-        msg = RegexStartH.Replace(msg, "'");
 
         // spaces out ! ? : and ;.
         msg = RegexSpacePunctuation.Replace(msg, " $&");
@@ -51,7 +55,70 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
+        // Russian-Locale
+
+        foreach (Match match in RegexH.Matches(msg))
+        {
+            var uppercase = msg[match.Index] == 'Х';
+            var g = uppercase ? "Г" : "г";
+
+            // Если х стоит первой, то с некоторым шансом превращаем её в апостроф
+            if (match.Index == 0 && _random.Prob(0.5f) || match.Index != 0 && char.IsWhiteSpace(msg[match.Index - 1]))
+            {
+                msg = "'" + msg[(match.Index + 1)..];
+            }
+            // В противном случае, тупо конвентируем её в г
+            else
+            {
+                msg = msg[..match.Index] + g + msg[(match.Index + 1)..];
+            }
+        }
+
+        foreach (Match match in RegexR.Matches(msg))
+        {
+            var uppercase = msg[match.Index] == 'Р';
+            var g = uppercase ? "Г" : "г";
+            var h = "";
+            for (var i = 0; i < match.Value.Length; i++)
+            {
+                // Блять я не буду это комментировать.
+                if (uppercase && match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]) || msg[match.Index + match.Length].ToString().Equals(msg[match.Index + match.Length].ToString().ToUpper(), StringComparison.CurrentCulture))
+                    h += "Х";
+                else
+                    h += "х";
+            }
+
+            // Превращаем р в гх
+            msg = msg[..match.Index] + g + h + msg[(match.Index + h.Length)..];
+        }
+
+        foreach (Match match in RegexE.Matches(msg))
+        {
+            var uppercase = msg[match.Index] == 'Е';
+            var e = uppercase ? "Э" : "э";
+
+            // Превращаем е в э перед другими буквами
+            if (match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]))
+            {
+                msg = msg[..match.Index] + e + msg[(match.Index + 1)..];
+            }
+        }
+
+        foreach (Match match in RegexZ.Matches(msg))
+        {
+            var uppercase = msg[match.Index] == 'З';
+            var z = uppercase ? "Ж" : "ж";
+
+            // С шансом в 10 процентов превращаем з в ж для изображения звонкости
+            // ТУДУ: хз, мб ещё тильду после з влепливать с некоторым шансом?
+            if (_random.Prob(0.1f))
+            {
+                msg = msg[..match.Index] + z + msg[(match.Index + 1)..];
+            }
+        }
+
         return msg;
+
     }
 
     private void OnAccentGet(EntityUid uid, FrenchAccentComponent component, AccentGetEvent args)

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -11,15 +11,15 @@ namespace Content.Server.Speech.EntitySystems;
 public sealed class FrenchAccentSystem : EntitySystem
 {
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
-    // Russian-Locale-Start
-    [Dependency] private readonly IRobustRandom _random = default!;
-    // Russian-Locale-End
+    [Dependency] private readonly IRobustRandom _random = default!; // Russian-Locale
 
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
+    //Russian-Locale-Start
     private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
     private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
     private static readonly Regex RegexE = new("е", RegexOptions.IgnoreCase);
     private static readonly Regex RegexZ = new("з", RegexOptions.IgnoreCase);
+    //Russian-Locale-End
     private static readonly Regex RegexSpacePunctuation = new(@"(?<=\w\w)[!?;:](?!\w)", RegexOptions.IgnoreCase);
 
     public override void Initialize()
@@ -55,7 +55,7 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
-        // Russian-Locale
+        // Russian-Locale-Start
 
         foreach (Match match in RegexH.Matches(msg))
         {
@@ -74,7 +74,7 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
-        // Тут через это, потому-что при работе со списком он мутирует нахуй.
+        // Тут через это, потому-что при работе со списком он мутирует.
         msg = RegexR.Replace(msg, match =>
         {
             var uppercase = msg[match.Index] == 'Р';
@@ -82,8 +82,8 @@ public sealed class FrenchAccentSystem : EntitySystem
             var h = "";
             for (var i = 0; i < match.Value.Length; i++)
             {
-                // Блять я не буду это комментировать.
-                if (uppercase && match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]) || msg[match.Index + match.Length].ToString().Equals(msg[match.Index + match.Length].ToString().ToUpper(), StringComparison.CurrentCulture))
+                // Делает х заглавным, только если Р большая, но не первая буква в слове, и сообщении в целом. Также капитализирует её, след. после неё буква заглавная.
+                if (uppercase && match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]) || msg[match.Index + 1].ToString().Equals(msg[match.Index + 1].ToString().ToUpper(), StringComparison.CurrentCulture))
                     h += "Х";
                 else
                     h += "х";
@@ -117,6 +117,8 @@ public sealed class FrenchAccentSystem : EntitySystem
                 msg = msg[..match.Index] + z + msg[(match.Index + 1)..];
             }
         }
+
+        // Russian-Locale-End
 
         return msg;
 

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -14,6 +14,7 @@ public sealed class FrenchAccentSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!; // Russian-Locale
 
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexStartH = new(@"(?<!\w)h", RegexOptions.IgnoreCase);
     //Russian-Locale-Start
     private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
     private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
@@ -34,6 +35,9 @@ public sealed class FrenchAccentSystem : EntitySystem
         var msg = message;
 
         msg = _replacement.ApplyReplacements(msg, "french");
+
+        // replaces h with ' at the start of words.
+        msg = RegexStartH.Replace(msg, "'");
 
         // spaces out ! ? : and ;.
         msg = RegexSpacePunctuation.Replace(msg, " $&");
@@ -121,7 +125,6 @@ public sealed class FrenchAccentSystem : EntitySystem
         // Russian-Locale-End
 
         return msg;
-
     }
 
     private void OnAccentGet(EntityUid uid, FrenchAccentComponent component, AccentGetEvent args)

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -11,15 +11,15 @@ namespace Content.Server.Speech.EntitySystems;
 public sealed class FrenchAccentSystem : EntitySystem
 {
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
-    [Dependency] private readonly IRobustRandom _random = default!; // Russian-Locale
+    // Russian-Locale-Start
+    [Dependency] private readonly IRobustRandom _random = default!;
+    // Russian-Locale-End
 
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
-    //Russian-Locale-Start
     private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
     private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
     private static readonly Regex RegexE = new("е", RegexOptions.IgnoreCase);
     private static readonly Regex RegexZ = new("з", RegexOptions.IgnoreCase);
-    //Russian-Locale-End
     private static readonly Regex RegexSpacePunctuation = new(@"(?<=\w\w)[!?;:](?!\w)", RegexOptions.IgnoreCase);
 
     public override void Initialize()
@@ -55,7 +55,7 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
-        // Russian-Locale-Start
+        // Russian-Locale
 
         foreach (Match match in RegexH.Matches(msg))
         {
@@ -74,7 +74,7 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
-        // Тут через это, потому-что при работе со списком он мутирует.
+        // Тут через это, потому-что при работе со списком он мутирует нахуй.
         msg = RegexR.Replace(msg, match =>
         {
             var uppercase = msg[match.Index] == 'Р';
@@ -82,8 +82,8 @@ public sealed class FrenchAccentSystem : EntitySystem
             var h = "";
             for (var i = 0; i < match.Value.Length; i++)
             {
-                // Делает х заглавным, только если Р большая, но не первая буква в слове, и сообщении в целом. Также капитализирует её, след. после неё буква заглавная.
-                if (uppercase && match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]) || msg[match.Index + 1].ToString().Equals(msg[match.Index + 1].ToString().ToUpper(), StringComparison.CurrentCulture))
+                // Блять я не буду это комментировать.
+                if (uppercase && match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]) || msg[match.Index + match.Length].ToString().Equals(msg[match.Index + match.Length].ToString().ToUpper(), StringComparison.CurrentCulture))
                     h += "Х";
                 else
                     h += "х";
@@ -117,8 +117,6 @@ public sealed class FrenchAccentSystem : EntitySystem
                 msg = msg[..match.Index] + z + msg[(match.Index + 1)..];
             }
         }
-
-        // Russian-Locale-End
 
         return msg;
 

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -18,7 +18,7 @@ public sealed class FrenchAccentSystem : EntitySystem
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
     private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
     private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexE = new("e", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexE = new("е", RegexOptions.IgnoreCase);
     private static readonly Regex RegexZ = new("з", RegexOptions.IgnoreCase);
     private static readonly Regex RegexSpacePunctuation = new(@"(?<=\w\w)[!?;:](?!\w)", RegexOptions.IgnoreCase);
 
@@ -74,7 +74,8 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
-        foreach (Match match in RegexR.Matches(msg))
+        // Тут через это, потому-что при работе со списком он мутирует нахуй.
+        msg = RegexR.Replace(msg, match =>
         {
             var uppercase = msg[match.Index] == 'Р';
             var g = uppercase ? "Г" : "г";
@@ -89,8 +90,8 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
 
             // Превращаем р в гх
-            msg = msg[..match.Index] + g + h + msg[(match.Index + h.Length)..];
-        }
+            return g + h;
+        });
 
         foreach (Match match in RegexE.Matches(msg))
         {

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -1,7 +1,6 @@
 using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Shared.Speech;
-using Robust.Shared.Random;
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -11,15 +10,9 @@ namespace Content.Server.Speech.EntitySystems;
 public sealed class FrenchAccentSystem : EntitySystem
 {
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
-    // Russian-Locale-Start
-    [Dependency] private readonly IRobustRandom _random = default!;
-    // Russian-Locale-End
 
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexE = new("e", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexZ = new("з", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexStartH = new(@"(?<!\w)h", RegexOptions.IgnoreCase);
     private static readonly Regex RegexSpacePunctuation = new(@"(?<=\w\w)[!?;:](?!\w)", RegexOptions.IgnoreCase);
 
     public override void Initialize()
@@ -34,6 +27,9 @@ public sealed class FrenchAccentSystem : EntitySystem
         var msg = message;
 
         msg = _replacement.ApplyReplacements(msg, "french");
+
+        // replaces h with ' at the start of words.
+        msg = RegexStartH.Replace(msg, "'");
 
         // spaces out ! ? : and ;.
         msg = RegexSpacePunctuation.Replace(msg, " $&");
@@ -55,70 +51,7 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
-        // Russian-Locale
-
-        foreach (Match match in RegexH.Matches(msg))
-        {
-            var uppercase = msg[match.Index] == 'Х';
-            var g = uppercase ? "Г" : "г";
-
-            // Если х стоит первой, то с некоторым шансом превращаем её в апостроф
-            if (match.Index == 0 && _random.Prob(0.5f) || match.Index != 0 && char.IsWhiteSpace(msg[match.Index - 1]))
-            {
-                msg = "'" + msg[(match.Index + 1)..];
-            }
-            // В противном случае, тупо конвентируем её в г
-            else
-            {
-                msg = msg[..match.Index] + g + msg[(match.Index + 1)..];
-            }
-        }
-
-        foreach (Match match in RegexR.Matches(msg))
-        {
-            var uppercase = msg[match.Index] == 'Р';
-            var g = uppercase ? "Г" : "г";
-            var h = "";
-            for (var i = 0; i < match.Value.Length; i++)
-            {
-                // Блять я не буду это комментировать.
-                if (uppercase && match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]) || msg[match.Index + match.Length].ToString().Equals(msg[match.Index + match.Length].ToString().ToUpper(), StringComparison.CurrentCulture))
-                    h += "Х";
-                else
-                    h += "х";
-            }
-
-            // Превращаем р в гх
-            msg = msg[..match.Index] + g + h + msg[(match.Index + h.Length)..];
-        }
-
-        foreach (Match match in RegexE.Matches(msg))
-        {
-            var uppercase = msg[match.Index] == 'Е';
-            var e = uppercase ? "Э" : "э";
-
-            // Превращаем е в э перед другими буквами
-            if (match.Index != 0 && !char.IsWhiteSpace(msg[match.Index - 1]))
-            {
-                msg = msg[..match.Index] + e + msg[(match.Index + 1)..];
-            }
-        }
-
-        foreach (Match match in RegexZ.Matches(msg))
-        {
-            var uppercase = msg[match.Index] == 'З';
-            var z = uppercase ? "Ж" : "ж";
-
-            // С шансом в 10 процентов превращаем з в ж для изображения звонкости
-            // ТУДУ: хз, мб ещё тильду после з влепливать с некоторым шансом?
-            if (_random.Prob(0.1f))
-            {
-                msg = msg[..match.Index] + z + msg[(match.Index + 1)..];
-            }
-        }
-
         return msg;
-
     }
 
     private void OnAccentGet(EntityUid uid, FrenchAccentComponent component, AccentGetEvent args)

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -18,7 +18,7 @@ public sealed class FrenchAccentSystem : EntitySystem
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
     private static readonly Regex RegexH = new("х", RegexOptions.IgnoreCase);
     private static readonly Regex RegexR = new("[рР]+", RegexOptions.IgnoreCase);
-    private static readonly Regex RegexE = new("е", RegexOptions.IgnoreCase);
+    private static readonly Regex RegexE = new("e", RegexOptions.IgnoreCase);
     private static readonly Regex RegexZ = new("з", RegexOptions.IgnoreCase);
     private static readonly Regex RegexSpacePunctuation = new(@"(?<=\w\w)[!?;:](?!\w)", RegexOptions.IgnoreCase);
 
@@ -74,8 +74,7 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
         }
 
-        // Тут через это, потому-что при работе со списком он мутирует нахуй.
-        msg = RegexR.Replace(msg, match =>
+        foreach (Match match in RegexR.Matches(msg))
         {
             var uppercase = msg[match.Index] == 'Р';
             var g = uppercase ? "Г" : "г";
@@ -90,8 +89,8 @@ public sealed class FrenchAccentSystem : EntitySystem
             }
 
             // Превращаем р в гх
-            return g + h;
-        });
+            msg = msg[..match.Index] + g + h + msg[(match.Index + h.Length)..];
+        }
 
         foreach (Match match in RegexE.Matches(msg))
         {

--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 using Content.Server.Speech.Components;
 using Content.Shared.Speech;
-using Robust.Shared.Random; // Russian-Locale
+using Robust.Shared.Random;
 
 namespace Content.Server.Speech.EntitySystems;
 

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -66,14 +66,17 @@
   - type: ReplacementAccent
     accent: italian
 
-- type: trait
-  id: FrenchAccent
-  name: trait-french-name
-  description: trait-french-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: FrenchAccent
+# Corvax french removal start
+# Непереводимое звучание. Имитация француского акцента на русском выглядит как кавказский акцент.
+#- type: trait
+#  id: FrenchAccent
+#  name: trait-french-name
+#  description: trait-french-desc
+#  category: SpeechTraits
+#  cost: 1
+#  components:
+#  - type: FrenchAccent
+# Corvax french removal end
 
 - type: trait
   id: SpanishAccent


### PR DESCRIPTION
## Описание PR
Удалил акцент

## Почему
На данный момент в русском он ничего кроме проставления пробела после серьёзных знаков препиания не делает. Когда как в английском он помимо этого ещё и преобразует th в 'h.
Нашим переводчикам мой вариат перевода не понравился; лазику просто было чуть-чуть похуй, а цфиф долгое время убеждал меня заменить акцент на почти идентичный, но заверенный ИИ.
Поэтому, другого пути кроме удаления его из выбора в меню не вижу.
Ошибок с сериализацией вызвать не должно (вроде как).

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->