### PR TITLE
Добавить систему для дробления серерных реплеев по размеру

### DIFF
--- a/Content.Server/_Corvax/Replays/ReplaySplitterSystem.cs
+++ b/Content.Server/_Corvax/Replays/ReplaySplitterSystem.cs
@@ -1,0 +1,79 @@
+using System;
+using Content.Server.GameTicking;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Replays;
+
+namespace Content.Server.Replays;
+
+[CVarDefs]
+public sealed class ReplaySplitterCVars
+{
+    public static readonly CVarDef<int> SplitCompressedSize =
+        CVarDef.Create("replay.split_compressed_size", 200 * 1024, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> SplitUncompressedSize =
+        CVarDef.Create("replay.split_uncompressed_size", 800 * 1024, CVar.SERVERONLY | CVar.ARCHIVE);
+}
+
+/// <summary>
+/// A system for automatically splitting large server replays into parts.
+/// </summary>
+public sealed class ReplaySplitterSystem : EntitySystem
+{
+    [Dependency] private readonly IConsoleHost _console = default!;
+    [Dependency] private readonly IReplayRecordingManager _replayManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private long _maxCompressedBytes;
+    private long _maxUncompressedBytes;
+
+    private float _timer;
+    private const float CheckIntervalSeconds = 15f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_cfg, ReplaySplitterCVars.SplitCompressedSize, v => _maxCompressedBytes = v * 1024L, true);
+        Subs.CVar(_cfg, ReplaySplitterCVars.SplitUncompressedSize, v => _maxUncompressedBytes = v * 1024L, true);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_replayManager.IsRecording)
+            return;
+
+        _timer += frameTime;
+        if (_timer < CheckIntervalSeconds)
+            return;
+
+        _timer = 0f;
+
+        var stats = _replayManager.GetReplayStats();
+
+        if (stats.Size >= _maxCompressedBytes || stats.UncompressedSize >= _maxUncompressedBytes)
+        {
+            SplitReplay();
+        }
+    }
+
+    private void SplitReplay()
+    {
+        var ticker = Get<GameTicker>();
+
+        var dateStr = DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm");
+        var timeStr = ticker.RoundDuration().ToString(@"hh\-mm\-ss");
+
+        var replayName = $"{dateStr}-round_{ticker.RoundId}-started_{timeStr}";
+
+        _console.ExecuteCommand("replay_recording_stop");
+        _console.ExecuteCommand($"replay_recording_start \"{replayName}\"");
+
+        _console.ExecuteCommand($"echo [ReplaySplitter] Limit reached. New replay started: {replayName}");
+    }
+}

--- a/Resources/ConfigPresets/Corvax/elysium.toml
+++ b/Resources/ConfigPresets/Corvax/elysium.toml
@@ -23,3 +23,9 @@ time = 180.0
 [hub]
 advertise = true
 tags = "lang:ru,rp:low,rp:med,region:eu_e,tts"
+
+[replay]
+max_compressed_size = 1048576
+max_uncompressed_size = 8388608
+split_compressed_size = 102400
+split_uncompressed_size = 819200


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Добавлена новая система для разделения огромных серверных реплеей на части ограниченные по весу. Размер можно регулировать через CVars.

Также увеличен максимальный размер реплея.

## Почему / Баланс
Реплеи по 800 МБ не открываются ゜ー゜

## Технические детали
Реализовано через новую систему отправляющую консольные команды

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
Нужно на хосте докрутить заливание всех частей реплея (это точно дополнительно кодить надо?)

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
:cl:
- tweak: Серверные реплеи теперь дробятся на фрагменты приемлемого размера, а также теперь раунды записываются целиком