### PR TITLE
Небольшое изменение BallisticAmmoProviderComponent

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -13,14 +13,14 @@ public sealed partial class GunSystem
         // TODO: Combine with TakeAmmo
         if (ent.Comp.Entities.Count > 0)
         {
-            var existing = ent.Comp.Entities[^1];
-            ent.Comp.Entities.RemoveAt(ent.Comp.Entities.Count - 1);
+            var existing = ent.Comp.Entities[0];
+            ent.Comp.Entities.RemoveAt(0);
             DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
-
             Containers.Remove(existing, ent.Comp.Container);
             EnsureShootable(existing);
+            ammoEnt = existing;
         }
-        else if (ent.Comp.UnspawnedCount > 0)
+        else if (ent.Comp.UnspawnedCount > 0 && ent.Comp.Proto != null)
         {
             ent.Comp.UnspawnedCount--;
             DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.UnspawnedCount));

--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -18,6 +18,9 @@ public sealed partial class BallisticAmmoProviderComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public EntProtoId? Proto;
+    
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public List<EntProtoId> Protos = new();
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public int Capacity = 30;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -225,7 +225,24 @@ public abstract partial class SharedGunSystem
     {
         // TODO this should be part of the prototype, not set on map init.
         // Alternatively, just track spawned count, instead of unspawned count.
-        if (ent.Comp.Proto != null)
+        if (ent.Comp.Protos.Count > 0)
+        {
+            var spawnCount = Math.Min(ent.Comp.Protos.Count, ent.Comp.Capacity);
+    
+            for (var i = 0; i < spawnCount; i++)
+            {
+                var ammo = Spawn(ent.Comp.Protos[i], Transform(ent).Coordinates);
+                Containers.Insert(ammo, ent.Comp.Container);
+                ent.Comp.Entities.Add(ammo);
+            }
+    
+            ent.Comp.UnspawnedCount = 0;
+            DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
+            DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.UnspawnedCount));
+            UpdateBallisticAppearance(ent);
+            return;
+        }
+        else if (ent.Comp.Proto != null)
         {
             ent.Comp.UnspawnedCount = Math.Max(0, ent.Comp.Capacity - ent.Comp.Container.ContainedEntities.Count);
             UpdateBallisticAppearance(ent);
@@ -245,8 +262,8 @@ public abstract partial class SharedGunSystem
             EntityUid? ammoEntity = null;
             if (ent.Comp.Entities.Count > 0)
             {
-                var existingEnt = ent.Comp.Entities[^1];
-                ent.Comp.Entities.RemoveAt(ent.Comp.Entities.Count - 1);
+                var existingEnt = ent.Comp.Entities[0];
+                ent.Comp.Entities.RemoveAt(0);
                 DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
                 Containers.Remove(existingEnt, ent.Comp.Container);
                 ammoEntity = existingEnt;
@@ -257,17 +274,17 @@ public abstract partial class SharedGunSystem
                 DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.UnspawnedCount));
                 ammoEntity = Spawn(ent.Comp.Proto, args.Coordinates);
             }
-
+    
             if (ammoEntity is not { } ammoEnt)
                 continue;
 
             args.Ammo.Add((ammoEnt, EnsureShootable(ammoEnt)));
+    
             if (TryComp<BallisticAmmoSelfRefillerComponent>(ent, out var refiller))
             {
                 PauseSelfRefill((ent, refiller));
             }
         }
-
         UpdateBallisticAppearance(ent);
     }
 


### PR DESCRIPTION

<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Добавляет новое поле `Protos` в `BallisticAmmoProviderComponent`, позволяющее задавать содержимое контейнера списком прототипов и загружать различные типы боеприпасов в произвольном порядке.

## Почему / Баланс
Расширение возможностей прототипирования оружия.

## Технические детали
- `GunSystem.Ballistic.cs`
Изменение пары значений для корректной работы нового поля

- `BallisticAmmoProviderComponent.cs`
Добавление нового поля `Protos`

- `SharedGunSystem.Ballistic.cs`
Добавлена поддержка инициализации контейнера из списка прототипов.

## План тестирования
1. Создать магазин с использованием поля `Protos`.
2. Указать несколько различных типов патронов в заданном порядке.
3. Загрузить магазин в оружие.
4. Отстрелять все патроны.
5. Убедиться, что типы патронов извлекаются в порядке, заданном в `Protos`.

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я протестировал этот пул-реквест и написал инструкции по его проверке.
- [ ] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->
