### PR TITLE
Отображение Спонсорских Тиров

### DIFF
--- a/Content.Client/Corvax/SponsorOnlyHelpers.cs
+++ b/Content.Client/Corvax/SponsorOnlyHelpers.cs
@@ -1,11 +1,18 @@
-using Robust.Shared.Localization;
+using Content.Corvax.Interfaces.Shared;
 
 namespace Content.Client.Corvax;
 
 public static class SponsorOnlyHelpers
 {
-    public static string GetSponsorOnlySuffix()
+    public static string GetSponsorOnlySuffix(string prototypeId)
     {
+        if (IoCManager.Resolve<ISharedSponsorsManager>() is not { } sponsorsManager)
+            return " " + Loc.GetString("sponsor-only-text");
+
+        if (sponsorsManager.TryGetTierNameForPrototype(prototypeId, out var tierName) && !string.IsNullOrEmpty(tierName))
+            return " " + Loc.GetString("sponsor-only-tier-text", ("tierName", tierName));
+
+        // Fallback
         return " " + Loc.GetString("sponsor-only-text");
     }
 }

--- a/Content.Client/Corvax/TTS/TTSTab.xaml.cs
+++ b/Content.Client/Corvax/TTS/TTSTab.xaml.cs
@@ -118,7 +118,7 @@ public sealed partial class TTSTab : Control
             var selectButton = new Button
             {
                 Text = displayName,
-                ToolTip = canSelectVoice ? voice.ID : Loc.GetString("humanoid-profile-editor-voice-tooltip-sponsoronly"),
+                ToolTip = canSelectVoice ? voice.ID : GetSponsorOnlyTooltip(voice.ID),
                 HorizontalExpand = true,
                 Disabled = !canSelectVoice,
                 StyleClasses = { StyleClass.ButtonOpenRight }
@@ -158,6 +158,17 @@ public sealed partial class TTSTab : Control
 
         ResultsLabel.Text = Loc.GetString("humanoid-profile-editor-voice-match",
             ("filtered", _filteredVoices.Count), ("all", _allVoices.Count));
+    }
+
+    private string GetSponsorOnlyTooltip(string voiceId)
+    {
+        var sponsorsManager = IoCManager.Resolve<ISharedSponsorsManager>();
+        if (sponsorsManager?.TryGetTierNameForPrototype(voiceId, out var tier) == true)
+        {
+            return Loc.GetString("humanoid-profile-editor-voice-tooltip-sponsoronly-tier", ("tier", tier));
+        }
+
+        return Loc.GetString("humanoid-profile-editor-voice-tooltip-sponsoronly");
     }
 
     private bool CanUseVoice(TTSVoicePrototype voice)

--- a/Content.Client/Humanoid/LayerMarkingItem.xaml.cs
+++ b/Content.Client/Humanoid/LayerMarkingItem.xaml.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Input;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Content.Corvax.Interfaces.Shared; // Corvax-Sponsors
+using static Content.Client.Corvax.SponsorOnlyHelpers; // Corvax-Sponsors
 
 namespace Content.Client.Humanoid;
 
@@ -96,7 +97,12 @@ public sealed partial class LayerMarkingItem : BoxContainer, ISearchableControl
         // Corvax-Sponsors-Start
         if (_markingPrototype.SponsorOnly && _sponsorsManager != null && _interactive)
         {
-            SelectButton.Disabled = !_sponsorsManager.GetClientPrototypes().Contains(_markingPrototype.ID);
+            var hasAccess = _sponsorsManager?.GetClientPrototypes().Contains(_markingPrototype.ID) ?? false;
+            if (!hasAccess)
+            {
+                SelectButton.Disabled = true;
+                SelectButton.Text += GetSponsorOnlySuffix(_markingPrototype.ID);
+            }
         }
         // Corvax-Sponsors-End
     }

--- a/Content.Client/Humanoid/OrganMarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/OrganMarkingPicker.xaml.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Content.Corvax.Interfaces.Shared; // Corvax-Sponsors
 using Content.Shared.Body;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
@@ -16,7 +15,6 @@ public sealed partial class OrganMarkingPicker : Control
 {
     [Dependency] private MarkingManager _marking = default!;
     [Dependency] private IEntityManager _entity = default!;
-    private ISharedSponsorsManager? _sponsorsManager; // Corvax-Sponsors
 
     private readonly SpriteSystem _sprite;
 
@@ -29,7 +27,6 @@ public sealed partial class OrganMarkingPicker : Control
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
-        IoCManager.Instance!.TryResolveType(out _sponsorsManager); // Corvax-Sponsors
 
         _markingsModel = markingsModel;
         _layers = layers;
@@ -76,16 +73,6 @@ public sealed partial class OrganMarkingPicker : Control
         {
             var allMarkings =
                 _markingsModel.EnforceGroupAndSexRestrictions ? _marking.MarkingsByLayerAndGroupAndSex(layer, _group, organProfileData.Sex) : _marking.MarkingsByLayer(layer);
-
-            // Corvax-Sponsors-Start
-            /*if (_sponsorsManager != null)
-            {
-                var sponsorPrototypes = _sponsorsManager.GetClientPrototypes();
-                allMarkings = allMarkings
-                    .Where(m => !m.Value.SponsorOnly || sponsorPrototypes.Contains(m.Key))
-                    .ToDictionary(m => m.Key, m => m.Value);
-            }*/
-            // Corvax-Sponsors-End
 
             if (allMarkings.Count == 0)
                 continue;

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.Appearance.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.Appearance.cs
@@ -7,7 +7,7 @@ using Content.Shared.Preferences;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using static Content.Client.Corvax.SponsorOnlyHelpers;
+using static Content.Client.Corvax.SponsorOnlyHelpers; // Corvax-Sponsors
 
 namespace Content.Client.Lobby.UI;
 
@@ -161,8 +161,10 @@ public sealed partial class HumanoidProfileEditor
         {
             var name = Loc.GetString(_species[i].Name);
 
-            if (_species[i].SponsorOnly) // Corvax-Sponsors
-                name += GetSponsorOnlySuffix();
+            // Corvax-Sponsors-start
+            if (_species[i].SponsorOnly)
+                name += GetSponsorOnlySuffix(_species[i].ID);
+            // Corvax-Sponsors-end
 
             SpeciesButton.AddItem(name, i);
 

--- a/Content.Shared/Corvax/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
+++ b/Content.Shared/Corvax/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
@@ -23,21 +23,31 @@ public sealed partial class SponsorLoadoutEffect : LoadoutEffect
         if (session == null)
             return true;
 
-        var sponsorProtos = GetPrototypes(session, collection);
+        if (!collection.TryResolveType<ISharedSponsorsManager>(out var sponsorsManager))
+            return true;
+
+        var sponsorProtos = GetPrototypes(session, collection, sponsorsManager);
         if (!sponsorProtos.Contains(proto.ID))
         {
-            reason = FormattedMessage.FromMarkupOrThrow(Loc.GetString("loadout-sponsor-only"));
+            if (sponsorsManager.TryGetTierNameForPrototype(proto.ID, out var tierName) && !string.IsNullOrEmpty(tierName))
+            {
+                reason = FormattedMessage.FromMarkupOrThrow(
+                    Loc.GetString("loadout-sponsor-only-tier", ("tierName", tierName)));
+            }
+            else
+            {
+                reason = FormattedMessage.FromMarkupOrThrow(
+                    Loc.GetString("loadout-sponsor-only"));
+            }
+
             return false;
         }
 
         return true;
     }
 
-    public List<string> GetPrototypes(ICommonSession session, IDependencyCollection collection)
+    private List<string> GetPrototypes(ICommonSession session, IDependencyCollection collection, ISharedSponsorsManager sponsorsManager)
     {
-        if (!collection.TryResolveType<ISharedSponsorsManager>(out var sponsorsManager))
-            return new List<string>();
-
         var net = collection.Resolve<INetManager>();
 
         if (net.IsClient)

--- a/Corvax/Content.Corvax.Interfaces.Shared/ISharedSponsorsManager.cs
+++ b/Corvax/Content.Corvax.Interfaces.Shared/ISharedSponsorsManager.cs
@@ -16,4 +16,7 @@ public interface ISharedSponsorsManager
     public bool TryGetServerOocColor(NetUserId userId, [NotNullWhen(true)] out Color? color);
     public int GetServerExtraCharSlots(NetUserId userId);
     public bool HaveServerPriorityJoin(NetUserId userId);
+
+    // Shared
+    public bool TryGetTierNameForPrototype(string prototypeId, [NotNullWhen(true)] out string? tierName);
 }

--- a/Resources/Locale/ru-RU/corvax/preferences/loadouts.ftl
+++ b/Resources/Locale/ru-RU/corvax/preferences/loadouts.ftl
@@ -1,1 +1,2 @@
 loadout-sponsor-only = [color=yellow]Доступно только спонсорам.[/color]
+loadout-sponsor-only-tier = [color=yellow]Доступно только для уровня подписки {$tierName}.[/color]

--- a/Resources/Locale/ru-RU/corvax/species/species-ui.ftl
+++ b/Resources/Locale/ru-RU/corvax/species/species-ui.ftl
@@ -1,1 +1,2 @@
 sponsor-only-text = [СПОНСОР]
+sponsor-only-tier-text = [{$tierName}]

--- a/Resources/Locale/ru-RU/corvax/tts/tts-ui.ftl
+++ b/Resources/Locale/ru-RU/corvax/tts/tts-ui.ftl
@@ -7,6 +7,7 @@ humanoid-profile-editor-voice-other = Прочие
 humanoid-profile-editor-voice-play = ▶
 humanoid-profile-editor-voice-tooltip-play = Прослушать
 humanoid-profile-editor-voice-tooltip-sponsoronly = Доступно только спонсорам
+humanoid-profile-editor-voice-tooltip-sponsoronly-tier = Доступно только по подписке {$tier}
 humanoid-profile-editor-voice-category-tooltip = Показать голоса из {$category}
 humanoid-profile-editor-voice-match = Найдено: {$filtered}/{$all}
 tts-rate-limited = Вы генерируете TTS слишком быстро!


### PR DESCRIPTION
## Описание PR
- Добавлено отображение всего спонсорского контента в игре, теперь вы увидите какие вещи за какие подписки доступны не отходя от игры
- Добавлена возможность просмотра тем призраков в игре в спонсорском меню, даже если вы не имеете подписки как таковой
- Чуть-Чуть убран излишний код

Ну собственно и все

## Почему / Баланс
**Крутое ингейм дополнение спонсорки. Подписаться!**
_Медиа не будет, оно приняло ислам_

## Критические изменения
Не

**Список изменений**
:cl:
- add: Добавлено отображение тиров для конкретных спонсорских вещей, голосов, рас и тд
- tweak: Теперь любой может просмотреть доступные призрачные темы спонсорских гостов