### PR TITLE
МиниФикс отображения иконки

### DIFF
--- a/Resources/Prototypes/StatusIcon/security.yml
+++ b/Resources/Prototypes/StatusIcon/security.yml
@@ -33,7 +33,7 @@
   icon:
     sprite: /Textures/Interface/Misc/security_icons.rsi
     state: hud_suspected
-  
+
 - type: securityIcon
   parent: SecurityIcon
   id: SecurityIconHostile
@@ -69,8 +69,8 @@
   id: CrewBorderIcon
   priority: 2
   offset: -4
-  offsetHorizontal: 4
-  locationPreference: Right
+  offsetHorizontal: -4 # Corvax-TypingIndicator
+  locationPreference: Left # Corvax-TypingIndicator
   layer: Mod
   isShaded: true
   icon:
@@ -81,8 +81,8 @@
   id: CrewUncertainBorderIcon
   priority: 2
   offset: -4
-  offsetHorizontal: 4
-  locationPreference: Right
+  offsetHorizontal: -4 # Corvax-TypingIndicator
+  locationPreference: Left # Corvax-TypingIndicator
   layer: Mod
   isShaded: true
   icon:


### PR DESCRIPTION
## Описание PR
Исправлено отображение иконки членов экипажа станции и не совсем экипажа, круто в общем лайк подписка

## Почему / Баланс
Ковах апдате иконки, прауд оф ковах

## Медиа
#### До
<img width="449" height="560" alt="Content Client_6RX2EwoT6b" src="https://github.com/user-attachments/assets/c1b9c9bb-25f4-47f9-ab51-a4e48b6e7929" />

#### После
<img width="487" height="559" alt="Content Client_v9o2Ozm7n7" src="https://github.com/user-attachments/assets/f70336af-ea52-46c1-a05c-be46d25a3494" />

**Список изменений**
:cl:
- fix: Исправлено отображение худа у обозначения членов экипажа