### PR TITLE
Add TTS log Response

### DIFF
--- a/Content.Server/Corvax/TTS/TTSManager.cs
+++ b/Content.Server/Corvax/TTS/TTSManager.cs
@@ -102,7 +102,8 @@ public sealed partial class TTSManager
             var json = await response.Content.ReadFromJsonAsync<GenerateVoiceResponse>(cancellationToken: cts.Token);
             if (json.Results == null || json.Results.Count == 0)
             {
-                _sawmill.Error($"TTS API returned empty results for '{text}'");
+                var rawJson = await response.Content.ReadAsStringAsync(cancellationToken: cts.Token);
+                _sawmill.Error($"TTS API returned empty results for '{text}'. Response: {rawJson}");
                 return null;
             }
 


### PR DESCRIPTION
## Описание PR
Добавлено чтение json ответа от TTS менеджера, чтобы понять суть отсутствия ответа от TTS и по какой причине это соответственно произошло в боевой обстановке

## Почему / Баланс
мя-мя-мя-мя-мя, ОтладкаБля

## Технические детали
Да.

## Критические изменения
Не.